### PR TITLE
今日飲む薬チェック機能を追加

### DIFF
--- a/app/src/main/java/com/example/medicineshield/MainActivity.kt
+++ b/app/src/main/java/com/example/medicineshield/MainActivity.kt
@@ -20,8 +20,10 @@ import com.example.medicineshield.data.database.AppDatabase
 import com.example.medicineshield.data.repository.MedicationRepository
 import com.example.medicineshield.ui.screen.MedicationFormScreen
 import com.example.medicineshield.ui.screen.MedicationListScreen
+import com.example.medicineshield.ui.screen.TodayMedicationScreen
 import com.example.medicineshield.viewmodel.MedicationFormViewModel
 import com.example.medicineshield.viewmodel.MedicationListViewModel
+import com.example.medicineshield.viewmodel.TodayMedicationViewModel
 
 class MainActivity : ComponentActivity() {
     private lateinit var repository: MedicationRepository
@@ -32,7 +34,8 @@ class MainActivity : ComponentActivity() {
         val database = AppDatabase.getDatabase(applicationContext)
         repository = MedicationRepository(
             database.medicationDao(),
-            database.medicationTimeDao()
+            database.medicationTimeDao(),
+            database.medicationIntakeDao()
         )
 
         setContent {
@@ -61,8 +64,20 @@ fun MedicineShieldApp(repository: MedicationRepository) {
 
     NavHost(
         navController = navController,
-        startDestination = "medication_list"
+        startDestination = "today_medication"
     ) {
+        composable("today_medication") {
+            val viewModel: TodayMedicationViewModel = viewModel(
+                factory = TodayMedicationViewModelFactory(repository)
+            )
+            TodayMedicationScreen(
+                viewModel = viewModel,
+                onNavigateToMedicationList = {
+                    navController.navigate("medication_list")
+                }
+            )
+        }
+
         composable("medication_list") {
             val viewModel: MedicationListViewModel = viewModel(
                 factory = MedicationListViewModelFactory(repository)
@@ -130,6 +145,18 @@ class MedicationFormViewModelFactory(
     override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(MedicationFormViewModel::class.java)) {
             return MedicationFormViewModel(repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}
+
+class TodayMedicationViewModelFactory(
+    private val repository: MedicationRepository
+) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(TodayMedicationViewModel::class.java)) {
+            return TodayMedicationViewModel(repository) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/app/src/main/java/com/example/medicineshield/data/dao/MedicationIntakeDao.kt
+++ b/app/src/main/java/com/example/medicineshield/data/dao/MedicationIntakeDao.kt
@@ -1,0 +1,30 @@
+package com.example.medicineshield.data.dao
+
+import androidx.room.*
+import com.example.medicineshield.data.model.MedicationIntake
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface MedicationIntakeDao {
+    @Insert
+    suspend fun insert(intake: MedicationIntake): Long
+
+    @Update
+    suspend fun update(intake: MedicationIntake)
+
+    @Delete
+    suspend fun delete(intake: MedicationIntake)
+
+    @Query("SELECT * FROM medication_intakes WHERE scheduledDate = :date ORDER BY scheduledTime ASC")
+    fun getIntakesByDate(date: String): Flow<List<MedicationIntake>>
+
+    @Query("SELECT * FROM medication_intakes WHERE medicationId = :medicationId AND scheduledDate = :date AND scheduledTime = :time")
+    suspend fun getIntakeByMedicationAndDateTime(
+        medicationId: Long,
+        date: String,
+        time: String
+    ): MedicationIntake?
+
+    @Query("DELETE FROM medication_intakes WHERE scheduledDate < :date")
+    suspend fun deleteOldIntakes(date: String)
+}

--- a/app/src/main/java/com/example/medicineshield/data/database/AppDatabase.kt
+++ b/app/src/main/java/com/example/medicineshield/data/database/AppDatabase.kt
@@ -5,24 +5,50 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import com.example.medicineshield.data.dao.MedicationDao
+import com.example.medicineshield.data.dao.MedicationIntakeDao
 import com.example.medicineshield.data.dao.MedicationTimeDao
 import com.example.medicineshield.data.model.Medication
+import com.example.medicineshield.data.model.MedicationIntake
 import com.example.medicineshield.data.model.MedicationTime
 
 @Database(
-    entities = [Medication::class, MedicationTime::class],
-    version = 1,
+    entities = [Medication::class, MedicationTime::class, MedicationIntake::class],
+    version = 2,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun medicationDao(): MedicationDao
     abstract fun medicationTimeDao(): MedicationTimeDao
+    abstract fun medicationIntakeDao(): MedicationIntakeDao
 
     companion object {
         @Volatile
         private var INSTANCE: AppDatabase? = null
+
+        private val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL(
+                    """
+                    CREATE TABLE IF NOT EXISTS `medication_intakes` (
+                        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        `medicationId` INTEGER NOT NULL,
+                        `scheduledTime` TEXT NOT NULL,
+                        `scheduledDate` TEXT NOT NULL,
+                        `takenAt` INTEGER,
+                        `createdAt` INTEGER NOT NULL,
+                        `updatedAt` INTEGER NOT NULL,
+                        FOREIGN KEY(`medicationId`) REFERENCES `medications`(`id`) ON DELETE CASCADE
+                    )
+                    """.trimIndent()
+                )
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_medication_intakes_medicationId` ON `medication_intakes` (`medicationId`)")
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_medication_intakes_scheduledDate` ON `medication_intakes` (`scheduledDate`)")
+            }
+        }
 
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
@@ -30,7 +56,9 @@ abstract class AppDatabase : RoomDatabase() {
                     context.applicationContext,
                     AppDatabase::class.java,
                     "medicine_shield_database"
-                ).build()
+                )
+                    .addMigrations(MIGRATION_1_2)
+                    .build()
                 INSTANCE = instance
                 instance
             }

--- a/app/src/main/java/com/example/medicineshield/data/model/MedicationIntake.kt
+++ b/app/src/main/java/com/example/medicineshield/data/model/MedicationIntake.kt
@@ -1,0 +1,29 @@
+package com.example.medicineshield.data.model
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+
+@Entity(
+    tableName = "medication_intakes",
+    foreignKeys = [
+        ForeignKey(
+            entity = Medication::class,
+            parentColumns = ["id"],
+            childColumns = ["medicationId"],
+            onDelete = ForeignKey.CASCADE
+        )
+    ],
+    indices = [Index("medicationId"), Index("scheduledDate")]
+)
+data class MedicationIntake(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val medicationId: Long,
+    val scheduledTime: String,  // HH:mm format (e.g., "09:00")
+    val scheduledDate: String,  // YYYY-MM-DD format (e.g., "2025-10-09")
+    val takenAt: Long? = null,  // timestamp in milliseconds, null = not taken yet
+    val createdAt: Long = System.currentTimeMillis(),
+    val updatedAt: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/example/medicineshield/data/model/TodayMedicationItem.kt
+++ b/app/src/main/java/com/example/medicineshield/data/model/TodayMedicationItem.kt
@@ -1,0 +1,9 @@
+package com.example.medicineshield.data.model
+
+data class TodayMedicationItem(
+    val medicationId: Long,
+    val medicationName: String,
+    val scheduledTime: String,
+    val isTaken: Boolean,
+    val takenAt: Long? = null
+)

--- a/app/src/main/java/com/example/medicineshield/data/repository/MedicationRepository.kt
+++ b/app/src/main/java/com/example/medicineshield/data/repository/MedicationRepository.kt
@@ -1,15 +1,23 @@
 package com.example.medicineshield.data.repository
 
 import com.example.medicineshield.data.dao.MedicationDao
+import com.example.medicineshield.data.dao.MedicationIntakeDao
 import com.example.medicineshield.data.dao.MedicationTimeDao
+import com.example.medicineshield.data.model.CycleType
 import com.example.medicineshield.data.model.Medication
+import com.example.medicineshield.data.model.MedicationIntake
 import com.example.medicineshield.data.model.MedicationTime
 import com.example.medicineshield.data.model.MedicationWithTimes
+import com.example.medicineshield.data.model.TodayMedicationItem
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import java.text.SimpleDateFormat
+import java.util.*
 
 class MedicationRepository(
     private val medicationDao: MedicationDao,
-    private val medicationTimeDao: MedicationTimeDao
+    private val medicationTimeDao: MedicationTimeDao,
+    private val medicationIntakeDao: MedicationIntakeDao
 ) {
     fun getAllMedicationsWithTimes(): Flow<List<MedicationWithTimes>> {
         return medicationDao.getAllMedicationsWithTimes()
@@ -43,5 +51,132 @@ class MedicationRepository(
 
     suspend fun deleteMedicationById(medicationId: Long) {
         medicationDao.deleteById(medicationId)
+    }
+
+    // ========== Today Medication Functions ==========
+
+    /**
+     * 今日の薬リストを取得する
+     */
+    fun getTodayMedications(): Flow<List<TodayMedicationItem>> {
+        val today = getCurrentDateString()
+        val medications = medicationDao.getAllMedicationsWithTimes()
+        val intakes = medicationIntakeDao.getIntakesByDate(today)
+
+        return combine(medications, intakes) { medList, intakeList ->
+            val todayItems = mutableListOf<TodayMedicationItem>()
+            val intakeMap = intakeList.associateBy { "${it.medicationId}_${it.scheduledTime}" }
+
+            for (medWithTimes in medList) {
+                if (shouldTakeMedicationToday(medWithTimes.medication)) {
+                    for (medTime in medWithTimes.times) {
+                        val key = "${medWithTimes.medication.id}_${medTime.time}"
+                        val intake = intakeMap[key]
+
+                        todayItems.add(
+                            TodayMedicationItem(
+                                medicationId = medWithTimes.medication.id,
+                                medicationName = medWithTimes.medication.name,
+                                scheduledTime = medTime.time,
+                                isTaken = intake?.takenAt != null,
+                                takenAt = intake?.takenAt
+                            )
+                        )
+                    }
+                }
+            }
+
+            todayItems.sortedBy { it.scheduledTime }
+        }
+    }
+
+    /**
+     * 服用記録を更新する（チェック/チェック解除）
+     */
+    suspend fun updateIntakeStatus(medicationId: Long, scheduledTime: String, isTaken: Boolean) {
+        val today = getCurrentDateString()
+        val existingIntake = medicationIntakeDao.getIntakeByMedicationAndDateTime(
+            medicationId, today, scheduledTime
+        )
+
+        if (isTaken) {
+            if (existingIntake == null) {
+                // 新規作成
+                medicationIntakeDao.insert(
+                    MedicationIntake(
+                        medicationId = medicationId,
+                        scheduledTime = scheduledTime,
+                        scheduledDate = today,
+                        takenAt = System.currentTimeMillis()
+                    )
+                )
+            } else {
+                // 更新
+                medicationIntakeDao.update(
+                    existingIntake.copy(
+                        takenAt = System.currentTimeMillis(),
+                        updatedAt = System.currentTimeMillis()
+                    )
+                )
+            }
+        } else {
+            // チェック解除
+            if (existingIntake != null) {
+                medicationIntakeDao.update(
+                    existingIntake.copy(
+                        takenAt = null,
+                        updatedAt = System.currentTimeMillis()
+                    )
+                )
+            }
+        }
+    }
+
+    /**
+     * 今日その薬を飲むべきかどうかを判定する
+     */
+    private fun shouldTakeMedicationToday(medication: Medication): Boolean {
+        val calendar = Calendar.getInstance()
+        val today = calendar.timeInMillis
+
+        // 期間チェック
+        if (today < medication.startDate) return false
+        if (medication.endDate != null && today > medication.endDate) return false
+
+        return when (medication.cycleType) {
+            CycleType.DAILY -> true
+
+            CycleType.WEEKLY -> {
+                // 曜日チェック (0=日曜, 1=月曜, ..., 6=土曜)
+                val todayDayOfWeek = calendar.get(Calendar.DAY_OF_WEEK) - 1
+                val allowedDays = medication.cycleValue?.split(",")?.map { it.toIntOrNull() } ?: emptyList()
+                todayDayOfWeek in allowedDays
+            }
+
+            CycleType.INTERVAL -> {
+                // N日ごとチェック
+                val intervalDays = medication.cycleValue?.toIntOrNull() ?: return false
+                val daysSinceStart = ((today - medication.startDate) / (1000 * 60 * 60 * 24)).toInt()
+                daysSinceStart % intervalDays == 0
+            }
+        }
+    }
+
+    /**
+     * 現在の日付を YYYY-MM-DD 形式で取得
+     */
+    private fun getCurrentDateString(): String {
+        val sdf = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        return sdf.format(Date())
+    }
+
+    /**
+     * 古い服用記録を削除（オプション: クリーンアップ用）
+     */
+    suspend fun cleanupOldIntakes(daysToKeep: Int = 30) {
+        val calendar = Calendar.getInstance()
+        calendar.add(Calendar.DAY_OF_YEAR, -daysToKeep)
+        val cutoffDate = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(calendar.time)
+        medicationIntakeDao.deleteOldIntakes(cutoffDate)
     }
 }

--- a/app/src/main/java/com/example/medicineshield/ui/screen/TodayMedicationScreen.kt
+++ b/app/src/main/java/com/example/medicineshield/ui/screen/TodayMedicationScreen.kt
@@ -1,0 +1,224 @@
+package com.example.medicineshield.ui.screen
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.List
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.medicineshield.data.model.TodayMedicationItem
+import com.example.medicineshield.viewmodel.TodayMedicationViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TodayMedicationScreen(
+    viewModel: TodayMedicationViewModel,
+    onNavigateToMedicationList: () -> Unit
+) {
+    val todayMedications by viewModel.todayMedications.collectAsState()
+    val todayDate by viewModel.todayDate.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("今日飲む薬") },
+                actions = {
+                    IconButton(onClick = onNavigateToMedicationList) {
+                        Icon(
+                            imageVector = Icons.Default.List,
+                            contentDescription = "薬一覧"
+                        )
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            // 日付表示
+            Text(
+                text = todayDate,
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Bold,
+                modifier = Modifier.padding(16.dp)
+            )
+
+            when {
+                isLoading -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
+                    }
+                }
+
+                todayMedications.isEmpty() -> {
+                    EmptyMedicationState(onNavigateToMedicationList)
+                }
+
+                else -> {
+                    MedicationList(
+                        medications = todayMedications,
+                        onToggleTaken = { medicationId, scheduledTime, isTaken ->
+                            viewModel.toggleMedicationTaken(medicationId, scheduledTime, isTaken)
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun EmptyMedicationState(onNavigateToMedicationList: () -> Unit) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Text(
+                text = "今日飲む薬はありません",
+                fontSize = 18.sp,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(
+                onClick = onNavigateToMedicationList
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Add,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp)
+                )
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("薬を追加する")
+            }
+        }
+    }
+}
+
+@Composable
+fun MedicationList(
+    medications: List<TodayMedicationItem>,
+    onToggleTaken: (Long, String, Boolean) -> Unit
+) {
+    // 時刻でグループ化
+    val groupedMedications = medications.groupBy { it.scheduledTime }
+
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        groupedMedications.forEach { (time, items) ->
+            item {
+                TimeHeader(time)
+            }
+
+            items(items) { medication ->
+                MedicationItem(
+                    medication = medication,
+                    onToggleTaken = onToggleTaken
+                )
+            }
+
+            item {
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
+    }
+}
+
+@Composable
+fun TimeHeader(time: String) {
+    Text(
+        text = time,
+        fontSize = 16.sp,
+        fontWeight = FontWeight.SemiBold,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(vertical = 8.dp)
+    )
+}
+
+@Composable
+fun MedicationItem(
+    medication: TodayMedicationItem,
+    onToggleTaken: (Long, String, Boolean) -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 4.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = if (medication.isTaken) {
+                MaterialTheme.colorScheme.surfaceVariant
+            } else {
+                MaterialTheme.colorScheme.surface
+            }
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            Column(
+                modifier = Modifier.weight(1f)
+            ) {
+                Text(
+                    text = medication.medicationName,
+                    fontSize = 16.sp,
+                    fontWeight = FontWeight.Medium
+                )
+                if (medication.isTaken && medication.takenAt != null) {
+                    Text(
+                        text = formatTakenTime(medication.takenAt),
+                        fontSize = 12.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
+            }
+
+            Checkbox(
+                checked = medication.isTaken,
+                onCheckedChange = {
+                    onToggleTaken(
+                        medication.medicationId,
+                        medication.scheduledTime,
+                        medication.isTaken
+                    )
+                }
+            )
+        }
+    }
+}
+
+@Composable
+fun formatTakenTime(timestamp: Long): String {
+    val calendar = java.util.Calendar.getInstance()
+    calendar.timeInMillis = timestamp
+    return String.format(
+        "服用済み %02d:%02d",
+        calendar.get(java.util.Calendar.HOUR_OF_DAY),
+        calendar.get(java.util.Calendar.MINUTE)
+    )
+}

--- a/app/src/main/java/com/example/medicineshield/viewmodel/TodayMedicationViewModel.kt
+++ b/app/src/main/java/com/example/medicineshield/viewmodel/TodayMedicationViewModel.kt
@@ -1,0 +1,64 @@
+package com.example.medicineshield.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.medicineshield.data.model.TodayMedicationItem
+import com.example.medicineshield.data.repository.MedicationRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.*
+
+class TodayMedicationViewModel(
+    private val repository: MedicationRepository
+) : ViewModel() {
+
+    private val _todayMedications = MutableStateFlow<List<TodayMedicationItem>>(emptyList())
+    val todayMedications: StateFlow<List<TodayMedicationItem>> = _todayMedications.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val _todayDate = MutableStateFlow("")
+    val todayDate: StateFlow<String> = _todayDate.asStateFlow()
+
+    init {
+        loadTodayMedications()
+        updateTodayDate()
+    }
+
+    private fun loadTodayMedications() {
+        viewModelScope.launch {
+            _isLoading.value = true
+            repository.getTodayMedications().collect { medications ->
+                _todayMedications.value = medications
+                _isLoading.value = false
+            }
+        }
+    }
+
+    private fun updateTodayDate() {
+        val dateFormat = SimpleDateFormat("yyyy年MM月dd日 (E)", Locale.JAPANESE)
+        _todayDate.value = dateFormat.format(Date())
+    }
+
+    fun toggleMedicationTaken(medicationId: Long, scheduledTime: String, currentStatus: Boolean) {
+        viewModelScope.launch {
+            repository.updateIntakeStatus(medicationId, scheduledTime, !currentStatus)
+        }
+    }
+
+    fun refreshData() {
+        updateTodayDate()
+        loadTodayMedications()
+    }
+
+    /**
+     * 時刻でグループ化されたデータを取得
+     */
+    fun getMedicationsGroupedByTime(): Map<String, List<TodayMedicationItem>> {
+        return _todayMedications.value.groupBy { it.scheduledTime }
+    }
+}


### PR DESCRIPTION
## Summary
- 起動時に今日飲むべき薬を一覧表示
- 時刻ごとにグループ化されたUI
- チェックボックスで服用済み/未服用を記録
- 毎日・曜日指定・N日ごとの周期パターンに対応

## 変更内容

### 新規ファイル
- `MedicationIntake.kt`: 服用記録モデル
- `MedicationIntakeDao.kt`: 服用記録DAO
- `TodayMedicationItem.kt`: UI用データモデル
- `TodayMedicationViewModel.kt`: 今日の薬画面ViewModel
- `TodayMedicationScreen.kt`: 今日の薬一覧画面

### 変更ファイル
- `AppDatabase.kt`: v1→v2マイグレーション追加（MedicationIntakeテーブル）
- `MedicationRepository.kt`: 今日の薬取得・服用記録更新・周期計算ロジック追加
- `MainActivity.kt`: 起動画面をtoday_medicationに変更

## 実装詳細

### データ層
- MedicationIntakeテーブル追加（服用記録）
  - scheduledDate, scheduledTime, takenAt などのフィールド
  - medicationIdでMedicationテーブルと関連付け
- データベースマイグレーション（v1→v2）を安全に実装

### ビジネスロジック
- 周期パターンから今日飲むべき薬を計算
  - DAILY: 毎日
  - WEEKLY: 指定曜日
  - INTERVAL: N日ごと
- 服用記録の登録・更新処理

### UI
- Material3デザインを使用
- 時刻でグループ化したリスト表示
- チェック済みの薬は背景色を変更して視覚的にわかりやすく
- 空の場合は「薬を追加する」ボタンを表示

## Test plan
- [ ] アプリを起動して今日飲む薬画面が表示されることを確認
- [ ] 薬が登録されていない場合、空の状態が表示されることを確認
- [ ] 薬を追加して、今日飲む薬として表示されることを確認
- [ ] チェックボックスをタップして服用済み状態が保存されることを確認
- [ ] アプリを再起動しても服用状態が保持されることを確認
- [ ] 曜日指定・N日ごとのパターンで正しく今日の薬が表示されることを確認
- [ ] 右上のアイコンから薬一覧画面へ遷移できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)