### PR TITLE
パッケージ名をcom.exampleからnet.shugoに変更

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    namespace = "com.example.medicineshield"
+    namespace = "net.shugo.medicineshield"
     compileSdk = 34
 
     defaultConfig {
-        applicationId = "com.example.medicineshield"
+        applicationId = "net.shugo.medicineshield"
         minSdk = 24
         targetSdk = 34
         versionCode = 1

--- a/app/src/main/java/net/shugo/medicineshield/MainActivity.kt
+++ b/app/src/main/java/net/shugo/medicineshield/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.medicineshield
+package net.shugo.medicineshield
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -16,14 +16,14 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
-import com.example.medicineshield.data.database.AppDatabase
-import com.example.medicineshield.data.repository.MedicationRepository
-import com.example.medicineshield.ui.screen.MedicationFormScreen
-import com.example.medicineshield.ui.screen.MedicationListScreen
-import com.example.medicineshield.ui.screen.DailyMedicationScreen
-import com.example.medicineshield.viewmodel.MedicationFormViewModel
-import com.example.medicineshield.viewmodel.MedicationListViewModel
-import com.example.medicineshield.viewmodel.DailyMedicationViewModel
+import net.shugo.medicineshield.data.database.AppDatabase
+import net.shugo.medicineshield.data.repository.MedicationRepository
+import net.shugo.medicineshield.ui.screen.MedicationFormScreen
+import net.shugo.medicineshield.ui.screen.MedicationListScreen
+import net.shugo.medicineshield.ui.screen.DailyMedicationScreen
+import net.shugo.medicineshield.viewmodel.MedicationFormViewModel
+import net.shugo.medicineshield.viewmodel.MedicationListViewModel
+import net.shugo.medicineshield.viewmodel.DailyMedicationViewModel
 
 class MainActivity : ComponentActivity() {
     private lateinit var repository: MedicationRepository

--- a/app/src/main/java/net/shugo/medicineshield/data/dao/MedicationDao.kt
+++ b/app/src/main/java/net/shugo/medicineshield/data/dao/MedicationDao.kt
@@ -1,8 +1,8 @@
-package com.example.medicineshield.data.dao
+package net.shugo.medicineshield.data.dao
 
 import androidx.room.*
-import com.example.medicineshield.data.model.Medication
-import com.example.medicineshield.data.model.MedicationWithTimes
+import net.shugo.medicineshield.data.model.Medication
+import net.shugo.medicineshield.data.model.MedicationWithTimes
 import kotlinx.coroutines.flow.Flow
 
 @Dao

--- a/app/src/main/java/net/shugo/medicineshield/data/dao/MedicationIntakeDao.kt
+++ b/app/src/main/java/net/shugo/medicineshield/data/dao/MedicationIntakeDao.kt
@@ -1,7 +1,7 @@
-package com.example.medicineshield.data.dao
+package net.shugo.medicineshield.data.dao
 
 import androidx.room.*
-import com.example.medicineshield.data.model.MedicationIntake
+import net.shugo.medicineshield.data.model.MedicationIntake
 import kotlinx.coroutines.flow.Flow
 
 @Dao

--- a/app/src/main/java/net/shugo/medicineshield/data/dao/MedicationTimeDao.kt
+++ b/app/src/main/java/net/shugo/medicineshield/data/dao/MedicationTimeDao.kt
@@ -1,7 +1,7 @@
-package com.example.medicineshield.data.dao
+package net.shugo.medicineshield.data.dao
 
 import androidx.room.*
-import com.example.medicineshield.data.model.MedicationTime
+import net.shugo.medicineshield.data.model.MedicationTime
 
 @Dao
 interface MedicationTimeDao {

--- a/app/src/main/java/net/shugo/medicineshield/data/database/AppDatabase.kt
+++ b/app/src/main/java/net/shugo/medicineshield/data/database/AppDatabase.kt
@@ -1,4 +1,4 @@
-package com.example.medicineshield.data.database
+package net.shugo.medicineshield.data.database
 
 import android.content.Context
 import androidx.room.Database
@@ -7,12 +7,12 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
-import com.example.medicineshield.data.dao.MedicationDao
-import com.example.medicineshield.data.dao.MedicationIntakeDao
-import com.example.medicineshield.data.dao.MedicationTimeDao
-import com.example.medicineshield.data.model.Medication
-import com.example.medicineshield.data.model.MedicationIntake
-import com.example.medicineshield.data.model.MedicationTime
+import net.shugo.medicineshield.data.dao.MedicationDao
+import net.shugo.medicineshield.data.dao.MedicationIntakeDao
+import net.shugo.medicineshield.data.dao.MedicationTimeDao
+import net.shugo.medicineshield.data.model.Medication
+import net.shugo.medicineshield.data.model.MedicationIntake
+import net.shugo.medicineshield.data.model.MedicationTime
 
 @Database(
     entities = [Medication::class, MedicationTime::class, MedicationIntake::class],

--- a/app/src/main/java/net/shugo/medicineshield/data/database/Converters.kt
+++ b/app/src/main/java/net/shugo/medicineshield/data/database/Converters.kt
@@ -1,7 +1,7 @@
-package com.example.medicineshield.data.database
+package net.shugo.medicineshield.data.database
 
 import androidx.room.TypeConverter
-import com.example.medicineshield.data.model.CycleType
+import net.shugo.medicineshield.data.model.CycleType
 
 class Converters {
     @TypeConverter

--- a/app/src/main/java/net/shugo/medicineshield/data/model/CycleType.kt
+++ b/app/src/main/java/net/shugo/medicineshield/data/model/CycleType.kt
@@ -1,4 +1,4 @@
-package com.example.medicineshield.data.model
+package net.shugo.medicineshield.data.model
 
 enum class CycleType {
     DAILY,      // 毎日

--- a/app/src/main/java/net/shugo/medicineshield/data/model/DailyMedicationItem.kt
+++ b/app/src/main/java/net/shugo/medicineshield/data/model/DailyMedicationItem.kt
@@ -1,4 +1,4 @@
-package com.example.medicineshield.data.model
+package net.shugo.medicineshield.data.model
 
 data class DailyMedicationItem(
     val medicationId: Long,

--- a/app/src/main/java/net/shugo/medicineshield/data/model/Medication.kt
+++ b/app/src/main/java/net/shugo/medicineshield/data/model/Medication.kt
@@ -1,4 +1,4 @@
-package com.example.medicineshield.data.model
+package net.shugo.medicineshield.data.model
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey

--- a/app/src/main/java/net/shugo/medicineshield/data/model/MedicationIntake.kt
+++ b/app/src/main/java/net/shugo/medicineshield/data/model/MedicationIntake.kt
@@ -1,4 +1,4 @@
-package com.example.medicineshield.data.model
+package net.shugo.medicineshield.data.model
 
 import androidx.room.Entity
 import androidx.room.ForeignKey

--- a/app/src/main/java/net/shugo/medicineshield/data/model/MedicationTime.kt
+++ b/app/src/main/java/net/shugo/medicineshield/data/model/MedicationTime.kt
@@ -1,4 +1,4 @@
-package com.example.medicineshield.data.model
+package net.shugo.medicineshield.data.model
 
 import androidx.room.Entity
 import androidx.room.ForeignKey

--- a/app/src/main/java/net/shugo/medicineshield/data/model/MedicationWithTimes.kt
+++ b/app/src/main/java/net/shugo/medicineshield/data/model/MedicationWithTimes.kt
@@ -1,4 +1,4 @@
-package com.example.medicineshield.data.model
+package net.shugo.medicineshield.data.model
 
 import androidx.room.Embedded
 import androidx.room.Relation

--- a/app/src/main/java/net/shugo/medicineshield/data/repository/MedicationRepository.kt
+++ b/app/src/main/java/net/shugo/medicineshield/data/repository/MedicationRepository.kt
@@ -1,14 +1,14 @@
-package com.example.medicineshield.data.repository
+package net.shugo.medicineshield.data.repository
 
-import com.example.medicineshield.data.dao.MedicationDao
-import com.example.medicineshield.data.dao.MedicationIntakeDao
-import com.example.medicineshield.data.dao.MedicationTimeDao
-import com.example.medicineshield.data.model.CycleType
-import com.example.medicineshield.data.model.Medication
-import com.example.medicineshield.data.model.MedicationIntake
-import com.example.medicineshield.data.model.MedicationTime
-import com.example.medicineshield.data.model.MedicationWithTimes
-import com.example.medicineshield.data.model.DailyMedicationItem
+import net.shugo.medicineshield.data.dao.MedicationDao
+import net.shugo.medicineshield.data.dao.MedicationIntakeDao
+import net.shugo.medicineshield.data.dao.MedicationTimeDao
+import net.shugo.medicineshield.data.model.CycleType
+import net.shugo.medicineshield.data.model.Medication
+import net.shugo.medicineshield.data.model.MedicationIntake
+import net.shugo.medicineshield.data.model.MedicationTime
+import net.shugo.medicineshield.data.model.MedicationWithTimes
+import net.shugo.medicineshield.data.model.DailyMedicationItem
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import java.text.SimpleDateFormat

--- a/app/src/main/java/net/shugo/medicineshield/ui/screen/DailyMedicationScreen.kt
+++ b/app/src/main/java/net/shugo/medicineshield/ui/screen/DailyMedicationScreen.kt
@@ -1,4 +1,4 @@
-package com.example.medicineshield.ui.screen
+package net.shugo.medicineshield.ui.screen
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -16,8 +16,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.medicineshield.data.model.DailyMedicationItem
-import com.example.medicineshield.viewmodel.DailyMedicationViewModel
+import net.shugo.medicineshield.data.model.DailyMedicationItem
+import net.shugo.medicineshield.viewmodel.DailyMedicationViewModel
 import java.util.*
 
 @OptIn(ExperimentalMaterial3Api::class)

--- a/app/src/main/java/net/shugo/medicineshield/ui/screen/MedicationFormScreen.kt
+++ b/app/src/main/java/net/shugo/medicineshield/ui/screen/MedicationFormScreen.kt
@@ -1,4 +1,4 @@
-package com.example.medicineshield.ui.screen
+package net.shugo.medicineshield.ui.screen
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -15,8 +15,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
-import com.example.medicineshield.data.model.CycleType
-import com.example.medicineshield.viewmodel.MedicationFormViewModel
+import net.shugo.medicineshield.data.model.CycleType
+import net.shugo.medicineshield.viewmodel.MedicationFormViewModel
 import java.text.SimpleDateFormat
 import java.util.*
 

--- a/app/src/main/java/net/shugo/medicineshield/ui/screen/MedicationListScreen.kt
+++ b/app/src/main/java/net/shugo/medicineshield/ui/screen/MedicationListScreen.kt
@@ -1,4 +1,4 @@
-package com.example.medicineshield.ui.screen
+package net.shugo.medicineshield.ui.screen
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -13,9 +13,9 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.example.medicineshield.data.model.CycleType
-import com.example.medicineshield.data.model.MedicationWithTimes
-import com.example.medicineshield.viewmodel.MedicationListViewModel
+import net.shugo.medicineshield.data.model.CycleType
+import net.shugo.medicineshield.data.model.MedicationWithTimes
+import net.shugo.medicineshield.viewmodel.MedicationListViewModel
 import java.text.SimpleDateFormat
 import java.util.*
 

--- a/app/src/main/java/net/shugo/medicineshield/viewmodel/DailyMedicationViewModel.kt
+++ b/app/src/main/java/net/shugo/medicineshield/viewmodel/DailyMedicationViewModel.kt
@@ -1,9 +1,9 @@
-package com.example.medicineshield.viewmodel
+package net.shugo.medicineshield.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.medicineshield.data.model.DailyMedicationItem
-import com.example.medicineshield.data.repository.MedicationRepository
+import net.shugo.medicineshield.data.model.DailyMedicationItem
+import net.shugo.medicineshield.data.repository.MedicationRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/app/src/main/java/net/shugo/medicineshield/viewmodel/MedicationFormViewModel.kt
+++ b/app/src/main/java/net/shugo/medicineshield/viewmodel/MedicationFormViewModel.kt
@@ -1,10 +1,10 @@
-package com.example.medicineshield.viewmodel
+package net.shugo.medicineshield.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.medicineshield.data.model.CycleType
-import com.example.medicineshield.data.model.Medication
-import com.example.medicineshield.data.repository.MedicationRepository
+import net.shugo.medicineshield.data.model.CycleType
+import net.shugo.medicineshield.data.model.Medication
+import net.shugo.medicineshield.data.repository.MedicationRepository
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/app/src/main/java/net/shugo/medicineshield/viewmodel/MedicationListViewModel.kt
+++ b/app/src/main/java/net/shugo/medicineshield/viewmodel/MedicationListViewModel.kt
@@ -1,9 +1,9 @@
-package com.example.medicineshield.viewmodel
+package net.shugo.medicineshield.viewmodel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.example.medicineshield.data.model.MedicationWithTimes
-import com.example.medicineshield.data.repository.MedicationRepository
+import net.shugo.medicineshield.data.model.MedicationWithTimes
+import net.shugo.medicineshield.data.repository.MedicationRepository
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn


### PR DESCRIPTION
## Summary
- パッケージ名を`com.example.medicineshield`から`net.shugo.medicineshield`に変更
- デフォルトの`com.example`パッケージから、プロジェクト固有のパッケージ名に変更

## 変更内容

### パッケージ名の変更
- **変更前**: `com.example.medicineshield`
- **変更後**: `net.shugo.medicineshield`

### 変更ファイル

#### build.gradle.kts
- `namespace`: `com.example.medicineshield` → `net.shugo.medicineshield`
- `applicationId`: `com.example.medicineshield` → `net.shugo.medicineshield`

#### ディレクトリ構造
- `app/src/main/java/com/example/medicineshield/` → `app/src/main/java/net/shugo/medicineshield/`

#### 全Kotlinファイル（19ファイル）
- package宣言: `package com.example.medicineshield.*` → `package net.shugo.medicineshield.*`
- import文: `import com.example.medicineshield.*` → `import net.shugo.medicineshield.*`

### 変更対象ファイル
- MainActivity.kt
- data/dao/*.kt (3ファイル)
- data/database/*.kt (2ファイル)
- data/model/*.kt (7ファイル)
- data/repository/*.kt (1ファイル)
- ui/screen/*.kt (3ファイル)
- viewmodel/*.kt (3ファイル)

### AndroidManifest.xml
- 変更不要（相対パス `.MainActivity` を使用しているため）

## Test plan
- [x] クリーンビルドが正常に完了することを確認
- [ ] アプリが正常に起動することを確認
- [ ] 全ての機能が正常に動作することを確認

## 備考
- この変更により、アプリをアンインストールして再インストールする必要があります（applicationIdが変更されるため）
- 既存のデータベースデータは失われます

🤖 Generated with [Claude Code](https://claude.com/claude-code)