### PR TITLE
薬の開始日の日付比較バグを修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+MedicineShield is an Android medication management application built with Kotlin and Jetpack Compose. It helps users track their daily medication schedule with support for various medication cycles (daily, weekly, interval-based).
+
+**Package**: `net.shugo.medicineshield`
+**Min SDK**: 24
+**Target SDK**: 34
+
+## Build Commands
+
+```bash
+# Build the project
+./gradlew build
+
+# Clean build
+./gradlew clean build
+
+# Run debug build on connected device/emulator
+./gradlew installDebug
+
+# Run unit tests
+./gradlew test
+
+# Run Android instrumentation tests
+./gradlew connectedAndroidTest
+
+# Lint check
+./gradlew lint
+```
+
+## Architecture
+
+The app follows a clean architecture pattern with clear separation of concerns:
+
+### Data Layer
+- **Database**: Room database (`AppDatabase`) with version 2, includes migration from v1
+  - Location: `data/database/AppDatabase.kt`
+  - Entities: `Medication`, `MedicationTime`, `MedicationIntake`
+- **DAOs**: Separate DAOs for each entity in `data/dao/`
+- **Repository**: Single `MedicationRepository` coordinates all data operations
+  - Location: `data/repository/MedicationRepository.kt`
+  - Handles medication CRUD, intake tracking, and daily medication logic
+
+### Domain Models
+- **Medication**: Core medication entity with cycle configuration
+  - `CycleType` enum: DAILY, WEEKLY (specific days), INTERVAL (every N days)
+  - `cycleValue`: Stores comma-separated day indices (0=Sunday) for WEEKLY or interval days for INTERVAL
+- **MedicationTime**: Scheduled times for each medication (one-to-many relationship)
+- **MedicationIntake**: Records actual intake events (timestamped)
+- **DailyMedicationItem**: View model for displaying daily medication status
+- **MedicationWithTimes**: Relationship entity combining Medication with its MedicationTimes
+
+### UI Layer
+- **Navigation**: Single-activity architecture with Jetpack Navigation Compose
+  - Routes: `daily_medication` (start), `medication_list`, `add_medication`, `edit_medication/{id}`
+- **Screens** (in `ui/screen/`):
+  - `DailyMedicationScreen`: Main screen showing today's medications with date navigation
+  - `MedicationListScreen`: List all medications with edit/delete
+  - `MedicationFormScreen`: Add/edit medication form (reused for both operations)
+- **ViewModels** (in `viewmodel/`):
+  - Each screen has a dedicated ViewModel
+  - Factories defined in `MainActivity.kt` for dependency injection
+  - Repository passed via factory pattern
+
+### Key Logic
+- **Medication Scheduling** (`MedicationRepository:144-169`):
+  - `shouldTakeMedication()` determines if a medication should appear on a given date
+  - Handles date range checks and cycle type logic (daily, weekly days, interval days)
+- **Intake Tracking** (`MedicationRepository:98-139`):
+  - `updateIntakeStatus()` creates or updates intake records
+  - Supports checking/unchecking medications
+  - Uses compound key: `medicationId_scheduledTime_scheduledDate`
+
+## Development Notes
+
+### Database Migrations
+- Current version: 2
+- Migration 1→2 adds `medication_intakes` table
+- Add new migrations to `AppDatabase.companion.object` when schema changes
+
+### Dependency Injection
+- Currently uses manual DI via ViewModelFactory classes in `MainActivity.kt`
+- Repository instantiated in `MainActivity.onCreate()` and passed to screens
+- All three DAOs injected into MedicationRepository constructor
+
+### Date Handling
+- All dates stored as timestamps (Long, milliseconds since epoch)
+- Display format: "yyyy-MM-dd" for date strings in intake records
+- Calendar manipulation uses `java.util.Calendar`
+- Timezone-aware date parsing in `MedicationRepository`
+
+### Compose Best Practices
+- Material 3 components used throughout
+- ExperimentalMaterial3Api opt-in enabled globally in build.gradle.kts
+- ViewModel state observed via Compose State/Flow


### PR DESCRIPTION
## Summary
- 薬を登録した日に「飲む薬」画面に表示されないバグを修正
- 日付比較時に時刻を正規化するヘルパー関数を追加
- INTERVAL型の日数計算も正規化された日付を使用するように改善

## 問題
`Medication.startDate`に登録時の時刻が含まれるため、`MedicationRepository.shouldTakeMedication()`で`targetDate`(当日の00:00)と比較すると開始日より前と判定され、薬を登録した日の「飲む薬」画面に表示されない。

例:
- 薬を14:30に登録 → `startDate` = 2025-10-09 14:30:00
- 当日の「飲む薬」画面 → `targetDate` = 2025-10-09 00:00:00
- 比較結果: 00:00 < 14:30 → false (表示されない)

## 修正内容
1. `normalizeToStartOfDay()` ヘルパー関数を追加
   - タイムスタンプを日付の開始時刻(00:00:00.000)に正規化
   - `app/src/main/java/net/shugo/medicineshield/data/repository/MedicationRepository.kt:206-214`

2. `shouldTakeMedication()` の日付比較ロジックを修正
   - `startDate`, `endDate`, `targetDate` を全て正規化してから比較
   - `app/src/main/java/net/shugo/medicineshield/data/repository/MedicationRepository.kt:148-155`

3. INTERVAL型の日数計算も修正
   - 正規化された日付で日数差を計算
   - `app/src/main/java/net/shugo/medicineshield/data/repository/MedicationRepository.kt:170`

## Test plan
- [ ] 薬を新規登録し、登録した当日の「飲む薬」画面に表示されることを確認
- [ ] 毎日(DAILY)の薬が正しく表示されることを確認
- [ ] 毎週指定曜日(WEEKLY)の薬が正しい曜日に表示されることを確認
- [ ] N日ごと(INTERVAL)の薬が正しい間隔で表示されることを確認
- [ ] 開始日・終了日の範囲外に薬が表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)