### PR TITLE
日付変更時に複数のcollectが動作する問題を修正

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/viewmodel/DailyMedicationViewModel.kt
+++ b/app/src/main/java/net/shugo/medicineshield/viewmodel/DailyMedicationViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import net.shugo.medicineshield.data.model.DailyMedicationItem
 import net.shugo.medicineshield.data.repository.MedicationRepository
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -27,13 +28,18 @@ class DailyMedicationViewModel(
     private val _displayDateText = MutableStateFlow("")
     val displayDateText: StateFlow<String> = _displayDateText.asStateFlow()
 
+    private var loadJob: Job? = null
+
     init {
         loadMedicationsForSelectedDate()
         updateDisplayDate()
     }
 
     private fun loadMedicationsForSelectedDate() {
-        viewModelScope.launch {
+        // 前回のloadJobをキャンセル
+        loadJob?.cancel()
+
+        loadJob = viewModelScope.launch {
             _isLoading.value = true
             val dateString = formatDateToString(_selectedDate.value)
             repository.getMedications(dateString).collect { medications ->


### PR DESCRIPTION
## Summary
- 日付を変更した際に、古いcollectがキャンセルされずに残っていた問題を修正
- 複数の薬が勝手にチェックされる、違う日に表示が飛ぶなどの症状を解消

## 問題の詳細

### 発生していた症状
1. **複数の薬が勝手にチェックされる**
   - 1つの薬をチェックすると、他の薬も一緒にチェックされることがある
   
2. **違う日に表示が飛ぶ**
   - 日付を変更すると、意図しない日付のデータが表示されることがある

### 根本原因
`DailyMedicationViewModel.loadMedicationsForSelectedDate()` (`DailyMedicationViewModel.kt:38`)で、日付を変更するたびに新しい`collect`が開始されていたが、古い`collect`がキャンセルされずに残っていた。

```kotlin
// 修正前
private fun loadMedicationsForSelectedDate() {
    viewModelScope.launch {
        _isLoading.value = true
        val dateString = formatDateToString(_selectedDate.value)
        repository.getMedications(dateString).collect { medications ->
            _dailyMedications.value = medications  // 複数のcollectが同時にここを更新
            _isLoading.value = false
        }
    }
}
```

このため、以下のような状況が発生:
- 2024-01-10のcollectが動作中
- ユーザーが2024-01-11に日付を変更
- 2024-01-11のcollectも開始されるが、2024-01-10のcollectは残ったまま
- 両方のcollectが`_dailyMedications.value`を更新するため、データが混在

## 修正内容

### 変更ファイル
- `app/src/main/java/net/shugo/medicineshield/viewmodel/DailyMedicationViewModel.kt`

### 主な変更
1. **`loadJob: Job?`プロパティを追加** (line 31)
   ```kotlin
   private var loadJob: Job? = null
   ```
   - 現在実行中のcollectジョブを追跡

2. **日付変更時に前回のジョブをキャンセル** (line 39-40)
   ```kotlin
   private fun loadMedicationsForSelectedDate() {
       // 前回のloadJobをキャンセル
       loadJob?.cancel()
       
       loadJob = viewModelScope.launch {
           _isLoading.value = true
           val dateString = formatDateToString(_selectedDate.value)
           repository.getMedications(dateString).collect { medications ->
               _dailyMedications.value = medications
               _isLoading.value = false
           }
       }
   }
   ```

### 効果
- 日付を変更すると、古いcollectが確実にキャンセルされる
- 現在選択中の日付のcollectのみが動作
- 他の日付のデータ更新が現在の画面に反映されなくなる

## Test plan
- [ ] 薬をチェックして、他の薬が勝手にチェックされないことを確認
- [ ] 日付を前後に変更して、表示が正しい日付のままであることを確認
- [ ] 日付を素早く何度も変更して、表示が乱れないことを確認
- [ ] 複数の薬を順番にチェック/チェック解除して、正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)