### PR TITLE
UIのテキストを「薬」から「お薬」に変更

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/ui/screen/DailyMedicationScreen.kt
+++ b/app/src/main/java/net/shugo/medicineshield/ui/screen/DailyMedicationScreen.kt
@@ -36,12 +36,12 @@ fun DailyMedicationScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("飲む薬") },
+                title = { Text("お薬カレンダー") },
                 actions = {
                     IconButton(onClick = onNavigateToMedicationList) {
                         Icon(
                             imageVector = Icons.Default.List,
-                            contentDescription = "薬一覧"
+                            contentDescription = "お薬一覧"
                         )
                     }
                 }
@@ -72,7 +72,7 @@ fun DailyMedicationScreen(
                 }
 
                 dailyMedications.isEmpty() -> {
-                    EmptyMedicationState(onNavigateToMedicationList)
+                    EmptyMedicationState(selectedDate, onNavigateToMedicationList)
                 }
 
                 else -> {
@@ -194,7 +194,19 @@ fun DatePickerDialog(
 }
 
 @Composable
-fun EmptyMedicationState(onNavigateToMedicationList: () -> Unit) {
+fun EmptyMedicationState(selectedDate: Calendar, onNavigateToMedicationList: () -> Unit) {
+    // 今日かどうか判定
+    val today = Calendar.getInstance()
+    val isToday = selectedDate.get(Calendar.YEAR) == today.get(Calendar.YEAR) &&
+                  selectedDate.get(Calendar.DAY_OF_YEAR) == today.get(Calendar.DAY_OF_YEAR)
+    val isFuture = selectedDate.timeInMillis > today.timeInMillis
+
+    val message = when {
+        isToday -> "今日飲むお薬はありません"
+        isFuture -> "この日に飲むお薬はありません"
+        else -> "この日に飲んだお薬はありません"
+    }
+
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center
@@ -204,7 +216,7 @@ fun EmptyMedicationState(onNavigateToMedicationList: () -> Unit) {
             verticalArrangement = Arrangement.Center
         ) {
             Text(
-                text = "今日飲む薬はありません",
+                text = message,
                 fontSize = 18.sp,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
@@ -218,7 +230,7 @@ fun EmptyMedicationState(onNavigateToMedicationList: () -> Unit) {
                     modifier = Modifier.size(18.dp)
                 )
                 Spacer(modifier = Modifier.width(8.dp))
-                Text("薬を追加する")
+                Text("お薬を追加する")
             }
         }
     }

--- a/app/src/main/java/net/shugo/medicineshield/ui/screen/MedicationFormScreen.kt
+++ b/app/src/main/java/net/shugo/medicineshield/ui/screen/MedicationFormScreen.kt
@@ -35,7 +35,7 @@ fun MedicationFormScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(if (isEdit) "薬を編集" else "薬を追加") },
+                title = { Text(if (isEdit) "お薬を編集" else "お薬を追加") },
                 navigationIcon = {
                     IconButton(onClick = onNavigateBack) {
                         Icon(Icons.Default.ArrowBack, contentDescription = "戻る")
@@ -56,7 +56,7 @@ fun MedicationFormScreen(
                 OutlinedTextField(
                     value = formState.name,
                     onValueChange = { viewModel.updateName(it) },
-                    label = { Text("薬の名前") },
+                    label = { Text("お薬の名前") },
                     isError = formState.nameError != null,
                     supportingText = formState.nameError?.let { { Text(it) } },
                     modifier = Modifier.fillMaxWidth()
@@ -183,7 +183,7 @@ fun MedicationFormScreen(
                         modifier = Modifier.weight(1f)
                     ) {
                         Text(
-                            formState.endDate?.let { "終了日: ${formatDate(it)}" } ?: "終了日（省略可能）"
+                            formState.endDate?.let { "終了日: ${formatDate(it)}" } ?: "終了日: なし"
                         )
                     }
                     if (formState.endDate != null) {

--- a/app/src/main/java/net/shugo/medicineshield/ui/screen/MedicationListScreen.kt
+++ b/app/src/main/java/net/shugo/medicineshield/ui/screen/MedicationListScreen.kt
@@ -32,12 +32,12 @@ fun MedicationListScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("薬一覧") }
+                title = { Text("お薬一覧") }
             )
         },
         floatingActionButton = {
             FloatingActionButton(onClick = onAddMedication) {
-                Icon(Icons.Default.Add, contentDescription = "薬を追加")
+                Icon(Icons.Default.Add, contentDescription = "お薬を追加")
             }
         }
     ) { padding ->
@@ -49,7 +49,7 @@ fun MedicationListScreen(
                 contentAlignment = Alignment.Center
             ) {
                 Text(
-                    "登録されている薬はありません",
+                    "登録されているお薬はありません",
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -78,7 +78,7 @@ fun MedicationListScreen(
         AlertDialog(
             onDismissRequest = { medicationToDelete = null },
             title = { Text("確認") },
-            text = { Text("この薬を削除しますか?") },
+            text = { Text("このお薬を削除しますか?") },
             confirmButton = {
                 TextButton(
                     onClick = {

--- a/app/src/main/java/net/shugo/medicineshield/viewmodel/MedicationFormViewModel.kt
+++ b/app/src/main/java/net/shugo/medicineshield/viewmodel/MedicationFormViewModel.kt
@@ -46,7 +46,7 @@ class MedicationFormViewModel(
                 _formState.value = _formState.value.copy(
                     medicationId = mwt.medication.id,
                     name = mwt.medication.name,
-                    times = mwt.times.map { it.time },
+                    times = mwt.times.map { it.time }.sorted(),
                     cycleType = mwt.medication.cycleType,
                     cycleValue = mwt.medication.cycleValue,
                     startDate = mwt.medication.startDate,
@@ -63,6 +63,7 @@ class MedicationFormViewModel(
     fun addTime(time: String) {
         val currentTimes = _formState.value.times.toMutableList()
         currentTimes.add(time)
+        currentTimes.sort()
         _formState.value = _formState.value.copy(times = currentTimes, timesError = null)
     }
 


### PR DESCRIPTION
## Summary
- DailyMedicationScreenのタイトルを「飲む薬」から「お薬カレンダー」に変更
- 空状態メッセージを選択日付に応じて変更:
  - 今日: "今日飲むお薬はありません"
  - 未来: "この日に飲むお薬はありません"
  - 過去: "この日に飲んだお薬はありません"
- MedicationListScreenのタイトルを「お薬一覧」に変更
- MedicationFormScreenのタイトルを「お薬を編集」/「お薬を追加」に変更
- その他、UI内のすべての「薬」を「お薬」に統一

## Test plan
- [ ] DailyMedicationScreenのタイトルが「お薬カレンダー」と表示される
- [ ] 今日の日付で薬がない場合、「今日飲むお薬はありません」と表示される
- [ ] 未来の日付で薬がない場合、「この日に飲むお薬はありません」と表示される
- [ ] 過去の日付で薬がない場合、「この日に飲んだお薬はありません」と表示される
- [ ] MedicationListScreenのタイトルが「お薬一覧」と表示される
- [ ] MedicationFormScreenで編集時は「お薬を編集」、追加時は「お薬を追加」と表示される
- [ ] 入力フィールドのラベルが「お薬の名前」と表示される
- [ ] その他のUI要素で「薬」が「お薬」に変更されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)