### PR TITLE
服用時刻の履歴管理機能を追加

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/data/dao/MedicationDao.kt
+++ b/app/src/main/java/net/shugo/medicineshield/data/dao/MedicationDao.kt
@@ -7,6 +7,9 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface MedicationDao {
+    @Query("SELECT * FROM medications ORDER BY createdAt DESC")
+    fun getAllMedications(): Flow<List<Medication>>
+
     @Transaction
     @Query("SELECT * FROM medications ORDER BY createdAt DESC")
     fun getAllMedicationsWithTimes(): Flow<List<MedicationWithTimes>>

--- a/app/src/main/java/net/shugo/medicineshield/data/dao/MedicationTimeDao.kt
+++ b/app/src/main/java/net/shugo/medicineshield/data/dao/MedicationTimeDao.kt
@@ -1,12 +1,43 @@
 package net.shugo.medicineshield.data.dao
 
 import androidx.room.*
+import kotlinx.coroutines.flow.Flow
 import net.shugo.medicineshield.data.model.MedicationTime
 
 @Dao
 interface MedicationTimeDao {
     @Query("SELECT * FROM medication_times WHERE medicationId = :medicationId")
     suspend fun getTimesForMedication(medicationId: Long): List<MedicationTime>
+
+    /**
+     * 全ての時刻を監視（Flowで変更を検知）
+     */
+    @Query("SELECT * FROM medication_times")
+    fun getAllTimesFlow(): Flow<List<MedicationTime>>
+
+    /**
+     * 指定された日付に有効な時刻を取得
+     * startDate <= targetDate AND (endDate IS NULL OR endDate > targetDate)
+     */
+    @Query("""
+        SELECT * FROM medication_times
+        WHERE medicationId = :medicationId
+        AND startDate <= :targetDate
+        AND (endDate IS NULL OR endDate > :targetDate)
+        ORDER BY time ASC
+    """)
+    suspend fun getTimesForMedicationOnDate(medicationId: Long, targetDate: Long): List<MedicationTime>
+
+    /**
+     * 現在有効な時刻を取得（endDate = null）
+     */
+    @Query("""
+        SELECT * FROM medication_times
+        WHERE medicationId = :medicationId
+        AND endDate IS NULL
+        ORDER BY time ASC
+    """)
+    suspend fun getCurrentTimesForMedication(medicationId: Long): List<MedicationTime>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(medicationTime: MedicationTime): Long

--- a/app/src/main/java/net/shugo/medicineshield/data/model/MedicationTime.kt
+++ b/app/src/main/java/net/shugo/medicineshield/data/model/MedicationTime.kt
@@ -15,11 +15,18 @@ import androidx.room.PrimaryKey
             onDelete = ForeignKey.CASCADE
         )
     ],
-    indices = [Index("medicationId")]
+    indices = [
+        Index("medicationId"),
+        Index(value = ["medicationId", "startDate", "endDate"])
+    ]
 )
 data class MedicationTime(
     @PrimaryKey(autoGenerate = true)
     val id: Long = 0,
     val medicationId: Long,
-    val time: String  // HH:mm format (e.g., "09:00", "14:30")
+    val time: String,  // HH:mm format (e.g., "09:00", "14:30")
+    val startDate: Long,  // この時刻が有効になった日付（タイムスタンプ）
+    val endDate: Long? = null,  // この時刻が無効になった日付（null=現在も有効）
+    val createdAt: Long = System.currentTimeMillis(),
+    val updatedAt: Long = System.currentTimeMillis()
 )

--- a/app/src/main/java/net/shugo/medicineshield/viewmodel/MedicationFormViewModel.kt
+++ b/app/src/main/java/net/shugo/medicineshield/viewmodel/MedicationFormViewModel.kt
@@ -41,7 +41,7 @@ class MedicationFormViewModel(
 
     fun loadMedication(medicationId: Long) {
         viewModelScope.launch {
-            val medicationWithTimes = repository.getMedicationWithTimesById(medicationId)
+            val medicationWithTimes = repository.getMedicationWithCurrentTimesById(medicationId)
             medicationWithTimes?.let { mwt ->
                 _formState.value = _formState.value.copy(
                     medicationId = mwt.medication.id,


### PR DESCRIPTION
## 概要
- 服用時刻に有効期間（startDate/endDate）を追加し、時刻の変更履歴を管理できるようにした
- 時刻を削除しても過去の日付ではその時刻が表示され、服用記録の整合性が保たれる
- 編集画面では現在有効な時刻のみ表示し、Flowで変更をリアルタイム検知する

## 主な変更内容

### データベース
- `MedicationTime`エンティティに`startDate`/`endDate`フィールドを追加
- データベースマイグレーション（v2→v3）を実装
- 既存データは`startDate=0`（過去から有効）で移行

### ロジック
- 時刻削除時は論理削除（`endDate`を設定）により履歴を保持
- 日付ベースで有効な時刻を取得するクエリを追加
- `getMedications()`で3つのFlowを組み合わせ、時刻変更をリアルタイム検知

### UI
- 編集画面では現在有効な時刻（`endDate=null`）のみ表示
- 日別薬画面では対象日に有効だった時刻を表示

## テスト計画
- [x] ユニットテスト（全15テスト成功）
- [ ] 時刻を削除→過去の日付で削除した時刻が表示されることを確認
- [ ] 時刻を追加→過去の日付で追加した時刻が表示されないことを確認
- [ ] 時刻を編集→編集画面で現在の時刻のみ表示されることを確認
- [ ] 時刻を編集→保存後、日別薬画面で即座に反映されることを確認
- [x] データベースマイグレーション（v2→v3）が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)