### PR TITLE
薬の編集画面で既存の服用時刻を編集できる機能を追加

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/viewmodel/MedicationFormViewModel.kt
+++ b/app/src/main/java/net/shugo/medicineshield/viewmodel/MedicationFormViewModel.kt
@@ -75,6 +75,15 @@ class MedicationFormViewModel(
         }
     }
 
+    fun updateTime(index: Int, newTime: String) {
+        val currentTimes = _formState.value.times.toMutableList()
+        if (index in currentTimes.indices) {
+            currentTimes[index] = newTime
+            currentTimes.sort()
+            _formState.value = _formState.value.copy(times = currentTimes, timesError = null)
+        }
+    }
+
     fun updateCycleType(cycleType: CycleType) {
         _formState.value = _formState.value.copy(
             cycleType = cycleType,


### PR DESCRIPTION
## 概要
- 薬の編集画面で、既存の服用時刻をタップすると編集ダイアログが開き、時刻を変更できる機能を追加
- 時刻追加（新規）と時刻編集（既存）の2つのモードに対応
- MedicationFormViewModelにupdateTime()メソッドを追加し、時刻リストの更新とソート機能を実装

## テスト計画
- [x] 薬の編集画面を開く
- [x] 既存の服用時刻をタップして、時刻編集ダイアログが表示されることを確認
- [x] ダイアログのタイトルが「時間を編集」になっていることを確認
- [x] 時刻選択ダイアログに既存の時刻が初期値として設定されていることを確認
- [x] 時刻を変更して確定し、リストが更新されることを確認
- [x] 変更後の時刻リストが正しくソートされていることを確認
- [x] 「時間を追加」ボタンをタップして、新規追加モードが動作することを確認
- [x] 新規追加時のダイアログタイトルが「時間を選択」になっていることを確認
- [x] 削除アイコンで時刻が削除できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)