### PR TITLE
薬削除時の確認ダイアログメッセージを改善

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/ui/screen/MedicationListScreen.kt
+++ b/app/src/main/java/net/shugo/medicineshield/ui/screen/MedicationListScreen.kt
@@ -103,7 +103,7 @@ fun MedicationListScreen(
         AlertDialog(
             onDismissRequest = { medicationToDelete = null },
             title = { Text("確認") },
-            text = { Text("このお薬を削除しますか?") },
+            text = { Text("服用履歴も削除されます。\n本当にこのお薬を削除しますか?") },
             confirmButton = {
                 TextButton(
                     onClick = {


### PR DESCRIPTION
## 概要
- 薬削除時の確認ダイアログに、服用履歴も同時に削除されることを明示的に通知するメッセージを追加
- メッセージを「服用履歴も削除されます。\n本当にこのお薬を削除しますか?」に変更し、ユーザーが削除の影響を理解しやすくした

## テスト計画
- [x] お薬一覧画面から薬の削除ボタンをタップ
- [x] 確認ダイアログに「服用履歴も削除されます。」と「本当にこのお薬を削除しますか?」が2行で表示されることを確認
- [x] 「はい」をタップして薬が削除され、服用履歴も削除されることを確認
- [x] 「いいえ」をタップして削除がキャンセルされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)