### PR TITLE
日付選択ダイアログの曜日表示問題を修正

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/ui/screen/DailyMedicationScreen.kt
+++ b/app/src/main/java/net/shugo/medicineshield/ui/screen/DailyMedicationScreen.kt
@@ -149,48 +149,35 @@ fun DateNavigationBar(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DatePickerDialog(
     selectedDate: Calendar,
     onDateSelected: (year: Int, month: Int, dayOfMonth: Int) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val datePickerState = rememberDatePickerState(
-        initialSelectedDateMillis = selectedDate.timeInMillis
-    )
+    val context = androidx.compose.ui.platform.LocalContext.current
 
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        confirmButton = {
-            TextButton(
-                onClick = {
-                    datePickerState.selectedDateMillis?.let { millis ->
-                        val calendar = Calendar.getInstance()
-                        calendar.timeInMillis = millis
-                        onDateSelected(
-                            calendar.get(Calendar.YEAR),
-                            calendar.get(Calendar.MONTH),
-                            calendar.get(Calendar.DAY_OF_MONTH)
-                        )
-                    }
-                }
-            ) {
-                Text("決定")
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = onDismiss) {
-                Text("キャンセル")
-            }
-        },
-        text = {
-            DatePicker(
-                state = datePickerState,
-                showModeToggle = false
-            )
+    DisposableEffect(Unit) {
+        val datePickerDialog = android.app.DatePickerDialog(
+            context,
+            { _, year, month, dayOfMonth ->
+                onDateSelected(year, month, dayOfMonth)
+            },
+            selectedDate.get(Calendar.YEAR),
+            selectedDate.get(Calendar.MONTH),
+            selectedDate.get(Calendar.DAY_OF_MONTH)
+        )
+
+        datePickerDialog.setOnCancelListener {
+            onDismiss()
         }
-    )
+
+        datePickerDialog.show()
+
+        onDispose {
+            datePickerDialog.dismiss()
+        }
+    }
 }
 
 @Composable


### PR DESCRIPTION
## 概要
- Material 3のDatePickerをAlertDialog内で使用すると曜日ヘッダー（金・土）が切れる問題を修正
- Android標準の`android.app.DatePickerDialog`に置き換えることで解決
- DailyMedicationScreenとMedicationFormScreenの両方のDatePickerDialogを修正

## テスト計画
- [x] DailyMedicationScreenで日付選択ダイアログを開き、曜日ヘッダー（特に金・土）が正しく表示されることを確認
- [ ] MedicationFormScreenで開始日選択ダイアログを開き、曜日が正しく表示されることを確認
- [ ] MedicationFormScreenで終了日選択ダイアログを開き、曜日が正しく表示されることを確認
- [ ] 日付選択後、正しい日付が選択されることを確認
- [ ] キャンセルボタンでダイアログが閉じることを確認
- [ ] ダイアログ外タップでダイアログが閉じることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)