### PR TITLE
MedicationTimeの有効性チェックをMedicationWithTimesに集約

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/data/model/MedicationWithTimes.kt
+++ b/app/src/main/java/net/shugo/medicineshield/data/model/MedicationWithTimes.kt
@@ -17,6 +17,25 @@ data class MedicationWithTimes(
     val configs: List<MedicationConfig> = emptyList()
 ) {
     /**
+     * 現在有効な時刻を取得
+     * @return 現在有効なMedicationTimeのリスト（時刻順にソート済み）
+     */
+    fun getCurrentTimes(): List<MedicationTime> {
+        return times.filter { it.validTo == null }.sortedBy { it.time }
+    }
+
+    /**
+     * 指定日時に有効な時刻を取得
+     * @param targetDate 対象日時のタイムスタンプ
+     * @return 指定日時に有効なMedicationTimeのリスト（時刻順にソート済み）
+     */
+    fun getTimesForDate(targetDate: Long): List<MedicationTime> {
+        return times
+            .filter { it.validFrom <= targetDate && (it.validTo == null || it.validTo > targetDate) }
+            .sortedBy { it.time }
+    }
+
+    /**
      * 現在有効な設定を取得
      * @return 現在有効なMedicationConfig、見つからない場合はnull
      */

--- a/app/src/main/java/net/shugo/medicineshield/notification/NotificationScheduler.kt
+++ b/app/src/main/java/net/shugo/medicineshield/notification/NotificationScheduler.kt
@@ -41,10 +41,10 @@ class NotificationScheduler(
         // すべての薬を取得
         val medications = repository.getAllMedicationsWithTimes().first()
 
-        // すべての時刻を収集
+        // すべての時刻を収集（現在有効なもののみ）
         val allTimes = mutableSetOf<String>()
         medications.forEach { med ->
-            med.times.forEach { time ->
+            med.getCurrentTimes().forEach { time ->
                 allTimes.add(time.time)
             }
         }
@@ -212,11 +212,8 @@ class NotificationScheduler(
 
         return medications.filter { medWithTimes ->
             // この薬がその時刻を持っているか（その日に有効な時刻）
-            val hasTime = medWithTimes.times.any { medTime ->
-                medTime.time == time &&
-                medTime.validFrom <= normalizedDateTime &&
-                (medTime.validTo == null || medTime.validTo > normalizedDateTime)
-            }
+            val validTimes = medWithTimes.getTimesForDate(normalizedDateTime)
+            val hasTime = validTimes.any { it.time == time }
             if (!hasTime) return@filter false
 
             // その日に有効なConfigを取得

--- a/app/src/main/java/net/shugo/medicineshield/ui/screen/MedicationListScreen.kt
+++ b/app/src/main/java/net/shugo/medicineshield/ui/screen/MedicationListScreen.kt
@@ -164,9 +164,10 @@ fun MedicationCard(
 
             Spacer(Modifier.height(8.dp))
 
-            // 服用時間
+            // 服用時間（現在有効なもののみ）
+            val activeTimes = medicationWithTimes.getCurrentTimes()
             Text(
-                "服用時間: ${times.joinToString(", ") { it.time }}",
+                "服用時間: ${activeTimes.joinToString(", ") { it.time }}",
                 style = MaterialTheme.typography.bodyMedium
             )
 


### PR DESCRIPTION
## 概要
- `validFrom`/`validTo`の直接参照を排除し、`getCurrentTimes()`と`getTimesForDate()`メソッドに集約
- お薬一覧で削除された時刻が表示されない問題を修正
- 服用時間が時刻順にソートされて表示されるように改善

## テスト計画
- [ ] お薬一覧画面で服用時間が時刻順に表示されることを確認
- [ ] お薬編集で時刻を削除した後、一覧画面に削除された時刻が表示されないことを確認
- [ ] お薬編集で時刻を追加した後、一覧画面に新しい時刻が時刻順で表示されることを確認
- [ ] 日別お薬画面で削除された時刻が表示されないことを確認
- [ ] 通知が削除された時刻に対してスケジュールされないことを確認
- [ ] 複数の時刻（例: 08:00, 12:00, 20:00）を持つお薬で正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)