### PR TITLE
updateMedicationWithTimesでcurrentConfigがnull時のvalidFromを0に修正

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/data/repository/MedicationRepository.kt
+++ b/app/src/main/java/net/shugo/medicineshield/data/repository/MedicationRepository.kt
@@ -149,14 +149,15 @@ class MedicationRepository(
                 medicationConfigDao.insert(newConfig)
             }
         } else {
-            // 存在しない場合は新規作成
+            // 存在しない場合は新規作成（最初のConfigとして）
+            // validFrom = 0にすることで過去すべての日付で有効
             val newConfig = MedicationConfig(
                 medicationId = medicationId,
                 cycleType = cycleType,
                 cycleValue = cycleValue,
                 medicationStartDate = startDate,
                 medicationEndDate = endDate,
-                validFrom = today,
+                validFrom = 0,
                 validTo = null
             )
             medicationConfigDao.insert(newConfig)


### PR DESCRIPTION
## 概要
- `updateMedicationWithTimes`で現在のConfigが存在しない場合、最初のConfigとして`validFrom = 0`で作成するように修正
- `insertMedicationWithTimes`との一貫性を保つ

## 問題
`updateMedicationWithTimes`の`currentConfig == null`のケース（最初のConfig作成時）で、`validFrom = today`となっていたため、過去の日付で薬が表示されない問題があった。

## 修正内容
- `else`ブロック（currentConfigがnullの場合）で`validFrom = 0`に変更
- コメントを追加して意図を明確化

## 効果
- `insertMedicationWithTimes`と同様に、最初のConfigは過去すべての日付で有効になる
- `medicationStartDate`から正しく表示されるようになる
- 編集時の既存Config変更は引き続き`validFrom = today`を使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)