### PR TITLE
CLAUDE.mdを更新してPRマージ前に必ず承認を得るように明記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,11 +36,19 @@ MedicineShield is an Android medication management application built with Kotlin
 
 4. **Testing & Review**
    - Run appropriate tests (unit, instrumentation, lint)
+   - Ensure build succeeds (`./gradlew build`)
    - Create pull request when ready for review
-   - Merge PR to main after approval
+   - **WAIT for user approval before merging**
+   - **NEVER merge PR without explicit user approval**
 
-5. **Branch Cleanup**
+5. **Merge to Main**
+   - Only merge after receiving explicit user approval
+   - Use `/merge` command or `gh pr merge` to merge the PR
+   - Verify merge was successful
+
+6. **Branch Cleanup**
    - Delete feature branch after PR is merged
+   - Confirm you're back on main branch with latest changes
 
 ## Build Commands
 


### PR DESCRIPTION
## 概要
- 開発ワークフローを更新し、PRマージ前に必ずユーザーの明示的な承認を得ることを必須化
- マージ手順を独立したステップとして明確化

## 変更内容

### ステップ4「Testing & Review」に追加
- ビルド成功の確認を追加
- **「WAIT for user approval before merging」を明記**
- **「NEVER merge PR without explicit user approval」を強調**

### 新規ステップ5「Merge to Main」を追加
- ユーザー承認後のみマージ可能
- マージコマンドの指定
- マージ成功の確認

### ステップ6「Branch Cleanup」を更新
- mainブランチへの切り替え確認を追加

## 理由
最近のPR #21、#22で自動的にマージを実行してしまったため、
ユーザーが変更内容を確認する機会がなかった。
今後は必ずユーザー承認を得てからマージするように徹底。

🤖 Generated with [Claude Code](https://claude.com/claude-code)