### PR TITLE
DatePickerDialog/TimePickerDialogの色をアプリのテーマに統一

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/ui/screen/DailyMedicationScreen.kt
+++ b/app/src/main/java/net/shugo/medicineshield/ui/screen/DailyMedicationScreen.kt
@@ -160,6 +160,7 @@ fun DatePickerDialog(
     DisposableEffect(Unit) {
         val datePickerDialog = android.app.DatePickerDialog(
             context,
+            net.shugo.medicineshield.R.style.Theme_MedicineShield_DateTimePicker,
             { _, year, month, dayOfMonth ->
                 onDateSelected(year, month, dayOfMonth)
             },

--- a/app/src/main/java/net/shugo/medicineshield/ui/screen/MedicationFormScreen.kt
+++ b/app/src/main/java/net/shugo/medicineshield/ui/screen/MedicationFormScreen.kt
@@ -337,6 +337,7 @@ fun TimePickerDialog(
     DisposableEffect(Unit) {
         val timePickerDialog = android.app.TimePickerDialog(
             context,
+            net.shugo.medicineshield.R.style.Theme_MedicineShield_DateTimePicker,
             { _, hourOfDay, minute ->
                 onConfirm(hourOfDay, minute)
             },
@@ -371,6 +372,7 @@ fun DatePickerDialog(
     DisposableEffect(Unit) {
         val datePickerDialog = android.app.DatePickerDialog(
             context,
+            net.shugo.medicineshield.R.style.Theme_MedicineShield_DateTimePicker,
             { _, year, month, dayOfMonth ->
                 val selectedCalendar = Calendar.getInstance().apply {
                     set(Calendar.YEAR, year)

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,4 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="Theme.MedicineShield" parent="android:Theme.Material.Light.NoActionBar" />
+
+    <!-- Material3スタイルのDatePicker/TimePickerテーマ -->
+    <style name="Theme.MedicineShield.DateTimePicker" parent="Theme.MedicineShield">
+        <!-- Material3のデフォルトカラーを使用 -->
+    </style>
 </resources>


### PR DESCRIPTION
## Summary
DatePickerDialog/TimePickerDialogが緑色で表示されていたため、アプリの他のUIと統一された色になるように修正しました。

## Changes
- `themes.xml`に`Theme.MedicineShield.DateTimePicker`スタイルを追加
- `DailyMedicationScreen.kt`のDatePickerDialogに新しいテーマを適用
- `MedicationFormScreen.kt`のDatePickerDialog/TimePickerDialogに新しいテーマを適用

## Technical Details
Android標準の`android.app.DatePickerDialog`と`android.app.TimePickerDialog`のコンストラクタで、テーマIDを指定することでアプリのテーマカラーを適用しています。

## Test Plan
- [ ] アプリをビルドして起動
- [ ] DailyMedicationScreenで日付選択ボタンをタップ
- [ ] DatePickerDialogの色がアプリのテーマと一致していることを確認
- [ ] MedicationFormScreenで開始日/終了日選択ボタンをタップ
- [ ] DatePickerDialogの色がアプリのテーマと一致していることを確認
- [ ] MedicationFormScreenで服用時間を追加/編集
- [ ] TimePickerDialogの色がアプリのテーマと一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)