### PR TITLE
Material 3のDatePicker/TimePickerに移行

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/ui/screen/DailyMedicationScreen.kt
+++ b/app/src/main/java/net/shugo/medicineshield/ui/screen/DailyMedicationScreen.kt
@@ -149,34 +149,42 @@ fun DateNavigationBar(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DatePickerDialog(
     selectedDate: Calendar,
     onDateSelected: (year: Int, month: Int, dayOfMonth: Int) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val context = androidx.compose.ui.platform.LocalContext.current
+    val datePickerState = rememberDatePickerState(
+        initialSelectedDateMillis = selectedDate.timeInMillis
+    )
 
-    DisposableEffect(Unit) {
-        val datePickerDialog = android.app.DatePickerDialog(
-            context,
-            { _, year, month, dayOfMonth ->
-                onDateSelected(year, month, dayOfMonth)
-            },
-            selectedDate.get(Calendar.YEAR),
-            selectedDate.get(Calendar.MONTH),
-            selectedDate.get(Calendar.DAY_OF_MONTH)
-        )
-
-        datePickerDialog.setOnCancelListener {
-            onDismiss()
+    androidx.compose.material3.DatePickerDialog(
+        onDismissRequest = onDismiss,
+        confirmButton = {
+            TextButton(onClick = {
+                datePickerState.selectedDateMillis?.let { millis ->
+                    val calendar = Calendar.getInstance().apply {
+                        timeInMillis = millis
+                    }
+                    onDateSelected(
+                        calendar.get(Calendar.YEAR),
+                        calendar.get(Calendar.MONTH),
+                        calendar.get(Calendar.DAY_OF_MONTH)
+                    )
+                }
+            }) {
+                Text("OK")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("キャンセル")
+            }
         }
-
-        datePickerDialog.show()
-
-        onDispose {
-            datePickerDialog.dismiss()
-        }
+    ) {
+        DatePicker(state = datePickerState)
     }
 }
 


### PR DESCRIPTION
## Summary
Android標準の`android.app.DatePickerDialog`/`android.app.TimePickerDialog`から、Material 3 Composeの`DatePicker`/`TimePicker`に移行しました。これにより、アプリ全体でMaterial 3のデザインとテーマカラーが統一されます。

## Changes
### DailyMedicationScreen.kt
- `DatePickerDialog`をMaterial 3の`DatePickerDialog` + `DatePicker`に変更
- `DisposableEffect`を使った複雑な実装からComposeネイティブな実装に変更

### MedicationFormScreen.kt
- `TimePickerDialog`をMaterial 3の`AlertDialog` + `TimePicker`に変更
- `DatePickerDialog`をMaterial 3の`DatePickerDialog` + `DatePicker`に変更
- すべてのダイアログから`DisposableEffect`を削除

## Technical Details
- `@OptIn(ExperimentalMaterial3Api::class)`を使用（build.gradle.ktsで既にプロジェクト全体でopt-in済み）
- `rememberDatePickerState`/`rememberTimePickerState`で状態管理
- Material 3のテーマカラーが自動的に適用される
- 日付の正規化（00:00:00）処理を維持

## Benefits
- ✅ UIの一貫性: アプリ全体でMaterial 3のデザインに統一
- ✅ 自動的なテーマ適用: Material 3のテーマカラーが自動的に適用される
- ✅ Composeネイティブ: DisposableEffectを使った複雑な実装が不要
- ✅ メンテナンス性: よりシンプルで読みやすいコード

## Test Plan
- [x] ビルドが成功することを確認
- [x] DailyMedicationScreenで日付選択ダイアログを表示
  - Material 3のデザインで表示されることを確認
  - 日付を選択して正しく反映されることを確認
- [x] MedicationFormScreenで開始日/終了日選択ダイアログを表示
  - Material 3のデザインで表示されることを確認
  - 日付を選択して正しく反映されることを確認
- [x] MedicationFormScreenで服用時間の追加/編集ダイアログを表示
  - Material 3のデザインで表示されることを確認
  - 時刻を選択して正しく反映されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)