### PR TITLE
Fix validTo date for medication times with intake records

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/data/repository/MedicationRepository.kt
+++ b/app/src/main/java/net/shugo/medicineshield/data/repository/MedicationRepository.kt
@@ -166,10 +166,23 @@ class MedicationRepository(
 
         // 削除する時刻（sequenceNumberが新しいリストにない）
         val timesToEnd = currentTimes.filter { it.sequenceNumber !in newMap }
+        val todayString = getDateString(today)
         timesToEnd.forEach { oldTime ->
+            // 今日のMedicationIntakeが存在するかチェック
+            val todayIntake = medicationIntakeDao.getIntakeByMedicationAndDateTime(
+                medicationId, todayString, oldTime.sequenceNumber
+            )
+
+            // Intakeが存在する場合は翌日の00:00:00、存在しない場合は今日の00:00:00
+            val validToDate = if (todayIntake != null) {
+                today + (24 * 60 * 60 * 1000)  // 翌日の00:00:00
+            } else {
+                today  // 今日の00:00:00
+            }
+
             medicationTimeDao.update(
                 oldTime.copy(
-                    validTo = today,  // 今日から無効（過去/未来の判定なし）
+                    validTo = validToDate,
                     updatedAt = now
                 )
             )


### PR DESCRIPTION
## Summary
- `MedicationRepository.updateMedicationWithTimes()`の`timesToEnd`処理を修正
- 削除される服用時刻に対して、今日の日付でMedicationIntakeが存在するかチェック
- Intakeが存在する場合は`validTo`を翌日の00:00:00に設定
- Intakeが存在しない場合は従来通り今日の00:00:00に設定

## 変更の理由
服用記録が既に記録されている時刻を削除する場合、`validTo`を今日の00:00:00に設定すると、その日の服用記録との整合性が取れなくなる問題がありました。今日既に服用記録がある場合は、その記録が有効であるべき期間（今日いっぱい）を保証するため、`validTo`を翌日の00:00:00に設定するように修正しました。

## Test plan
- [x] 服用時刻を削除する前に服用記録を作成
- [x] 服用時刻を削除
- [x] 削除された時刻の`validTo`が翌日の00:00:00になっていることを確認
- [x] 今日の日付で該当の服用記録が正しく表示されることを確認
- [ ] 服用記録がない状態で服用時刻を削除した場合、`validTo`が今日の00:00:00になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)