### PR TITLE
Add settings screen with notification toggle

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/MainActivity.kt
+++ b/app/src/main/java/net/shugo/medicineshield/MainActivity.kt
@@ -33,9 +33,11 @@ import net.shugo.medicineshield.notification.NotificationScheduler
 import net.shugo.medicineshield.ui.screen.MedicationFormScreen
 import net.shugo.medicineshield.ui.screen.MedicationListScreen
 import net.shugo.medicineshield.ui.screen.DailyMedicationScreen
+import net.shugo.medicineshield.ui.screen.SettingsScreen
 import net.shugo.medicineshield.viewmodel.MedicationFormViewModel
 import net.shugo.medicineshield.viewmodel.MedicationListViewModel
 import net.shugo.medicineshield.viewmodel.DailyMedicationViewModel
+import net.shugo.medicineshield.viewmodel.SettingsViewModel
 
 class MainActivity : ComponentActivity() {
     private lateinit var repository: MedicationRepository
@@ -132,6 +134,21 @@ fun MedicineShieldApp(repository: MedicationRepository) {
                 viewModel = viewModel,
                 onNavigateToMedicationList = {
                     navController.navigate("medication_list")
+                },
+                onNavigateToSettings = {
+                    navController.navigate("settings")
+                }
+            )
+        }
+
+        composable("settings") {
+            val viewModel: SettingsViewModel = viewModel(
+                factory = SettingsViewModelFactory(context.applicationContext, repository)
+            )
+            SettingsScreen(
+                viewModel = viewModel,
+                onNavigateBack = {
+                    navController.popBackStack()
                 }
             )
         }
@@ -218,6 +235,19 @@ class DailyMedicationViewModelFactory(
     override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(DailyMedicationViewModel::class.java)) {
             return DailyMedicationViewModel(application, repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}
+
+class SettingsViewModelFactory(
+    private val context: Context,
+    private val repository: MedicationRepository
+) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : androidx.lifecycle.ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(SettingsViewModel::class.java)) {
+            return SettingsViewModel(context, repository) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/app/src/main/java/net/shugo/medicineshield/data/preferences/SettingsPreferences.kt
+++ b/app/src/main/java/net/shugo/medicineshield/data/preferences/SettingsPreferences.kt
@@ -1,0 +1,33 @@
+package net.shugo.medicineshield.data.preferences
+
+import android.content.Context
+import android.content.SharedPreferences
+
+class SettingsPreferences(context: Context) {
+    private val sharedPreferences: SharedPreferences = context.getSharedPreferences(
+        PREFS_NAME,
+        Context.MODE_PRIVATE
+    )
+
+    companion object {
+        private const val PREFS_NAME = "medicine_shield_settings"
+        private const val KEY_NOTIFICATIONS_ENABLED = "notifications_enabled"
+        private const val DEFAULT_NOTIFICATIONS_ENABLED = true
+    }
+
+    /**
+     * Get whether notifications are enabled
+     */
+    fun isNotificationsEnabled(): Boolean {
+        return sharedPreferences.getBoolean(KEY_NOTIFICATIONS_ENABLED, DEFAULT_NOTIFICATIONS_ENABLED)
+    }
+
+    /**
+     * Set whether notifications are enabled
+     */
+    fun setNotificationsEnabled(enabled: Boolean) {
+        sharedPreferences.edit()
+            .putBoolean(KEY_NOTIFICATIONS_ENABLED, enabled)
+            .apply()
+    }
+}

--- a/app/src/main/java/net/shugo/medicineshield/ui/screen/DailyMedicationScreen.kt
+++ b/app/src/main/java/net/shugo/medicineshield/ui/screen/DailyMedicationScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.List
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.filled.KeyboardArrowRight
 import androidx.compose.material3.*
@@ -26,7 +27,8 @@ import java.util.*
 @Composable
 fun DailyMedicationScreen(
     viewModel: DailyMedicationViewModel,
-    onNavigateToMedicationList: () -> Unit
+    onNavigateToMedicationList: () -> Unit,
+    onNavigateToSettings: () -> Unit
 ) {
     val dailyMedications by viewModel.dailyMedications.collectAsState()
     val displayDateText by viewModel.displayDateText.collectAsState()
@@ -40,6 +42,12 @@ fun DailyMedicationScreen(
             TopAppBar(
                 title = { Text(stringResource(R.string.daily_medication_title)) },
                 actions = {
+                    IconButton(onClick = onNavigateToSettings) {
+                        Icon(
+                            imageVector = Icons.Default.Settings,
+                            contentDescription = stringResource(R.string.settings)
+                        )
+                    }
                     IconButton(onClick = onNavigateToMedicationList) {
                         Icon(
                             imageVector = Icons.Default.List,

--- a/app/src/main/java/net/shugo/medicineshield/ui/screen/SettingsScreen.kt
+++ b/app/src/main/java/net/shugo/medicineshield/ui/screen/SettingsScreen.kt
@@ -1,0 +1,90 @@
+package net.shugo.medicineshield.ui.screen
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import net.shugo.medicineshield.R
+import net.shugo.medicineshield.viewmodel.SettingsViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SettingsScreen(
+    viewModel: SettingsViewModel,
+    onNavigateBack: () -> Unit
+) {
+    val notificationsEnabled by viewModel.notificationsEnabled.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.settings)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowBack,
+                            contentDescription = stringResource(R.string.back)
+                        )
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+        ) {
+            // Notification Settings Section
+            Text(
+                text = stringResource(R.string.notification_settings),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                colors = CardDefaults.cardColors(
+                    containerColor = MaterialTheme.colorScheme.surface
+                )
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Column(
+                        modifier = Modifier.weight(1f)
+                    ) {
+                        Text(
+                            text = stringResource(R.string.enable_notifications),
+                            style = MaterialTheme.typography.bodyLarge
+                        )
+                        Spacer(modifier = Modifier.height(4.dp))
+                        Text(
+                            text = stringResource(R.string.notification_description),
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+
+                    Switch(
+                        checked = notificationsEnabled,
+                        onCheckedChange = { enabled ->
+                            viewModel.setNotificationsEnabled(enabled)
+                        }
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/net/shugo/medicineshield/viewmodel/SettingsViewModel.kt
+++ b/app/src/main/java/net/shugo/medicineshield/viewmodel/SettingsViewModel.kt
@@ -1,0 +1,66 @@
+package net.shugo.medicineshield.viewmodel
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import net.shugo.medicineshield.data.preferences.SettingsPreferences
+import net.shugo.medicineshield.data.repository.MedicationRepository
+import net.shugo.medicineshield.notification.NotificationScheduler
+
+class SettingsViewModel(
+    private val context: Context,
+    private val repository: MedicationRepository
+) : ViewModel() {
+
+    private val settingsPreferences = SettingsPreferences(context)
+    private val notificationScheduler = NotificationScheduler(context, repository)
+
+    private val _notificationsEnabled = MutableStateFlow(settingsPreferences.isNotificationsEnabled())
+    val notificationsEnabled: StateFlow<Boolean> = _notificationsEnabled.asStateFlow()
+
+    /**
+     * Toggle notification enabled/disabled
+     */
+    fun setNotificationsEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            // Update preference
+            settingsPreferences.setNotificationsEnabled(enabled)
+            _notificationsEnabled.value = enabled
+
+            if (enabled) {
+                // Re-schedule all notifications
+                notificationScheduler.rescheduleAllNotifications()
+            } else {
+                // Cancel all notifications
+                cancelAllNotifications()
+            }
+        }
+    }
+
+    /**
+     * Cancel all scheduled notifications
+     */
+    private suspend fun cancelAllNotifications() {
+        // Get all unique medication times and cancel their notifications
+        val medications = repository.getAllMedicationsWithTimes()
+        medications.collect { medList ->
+            val allTimes = mutableSetOf<String>()
+            medList.forEach { med ->
+                med.times.forEach { time ->
+                    allTimes.add(time.time)
+                }
+            }
+
+            allTimes.forEach { time ->
+                notificationScheduler.cancelNotificationForTime(time)
+            }
+        }
+
+        // Also cancel the daily refresh job
+        notificationScheduler.cancelDailyRefreshJob()
+    }
+}

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -79,6 +79,12 @@
     <string name="friday">金曜日</string>
     <string name="saturday">土曜日</string>
 
+    <!-- Settings Screen -->
+    <string name="settings">設定</string>
+    <string name="notification_settings">通知設定</string>
+    <string name="enable_notifications">通知を有効にする</string>
+    <string name="notification_description">服薬時刻にリマインダーを受け取る</string>
+
     <!-- Error Messages -->
     <string name="error_empty_name">お薬の名前を入力してください</string>
     <string name="error_no_times">少なくとも1つの服用時間を設定してください</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,6 +79,12 @@
     <string name="friday">Friday</string>
     <string name="saturday">Saturday</string>
 
+    <!-- Settings Screen -->
+    <string name="settings">Settings</string>
+    <string name="notification_settings">Notification Settings</string>
+    <string name="enable_notifications">Enable Notifications</string>
+    <string name="notification_description">Receive reminders when it\'s time to take medication</string>
+
     <!-- Error Messages -->
     <string name="error_empty_name">Please enter a medication name</string>
     <string name="error_no_times">Please set at least one medication time</string>


### PR DESCRIPTION
## Summary
- Add settings screen accessible from Daily Medication screen
- Implement notification enable/disable toggle functionality
- Persist notification preference using SharedPreferences

## Changes Made
### New Files
- **SettingsPreferences.kt** - Manages notification preference storage
- **SettingsScreen.kt** - Settings UI with notification toggle
- **SettingsViewModel.kt** - Settings business logic and notification scheduling

### Modified Files
- **MainActivity.kt** - Added settings route and SettingsViewModelFactory
- **DailyMedicationScreen.kt** - Added settings button in top app bar
- **NotificationScheduler.kt** - Added preference check and cancelDailyRefreshJob method
- **strings.xml** (EN/JA) - Added localized strings for settings

## Features
✅ Settings accessible via gear icon in Daily Medication screen
✅ Material 3 toggle switch with descriptive text
✅ Preference persisted across app restarts (default: enabled)
✅ Automatic notification rescheduling when enabled
✅ All notifications canceled when disabled
✅ Full Japanese and English localization support

## Test Plan
- [x] Build successful (`./gradlew build`)
- [ ] Navigate to Settings screen from Daily Medication
- [ ] Toggle notifications off and verify no notifications scheduled
- [ ] Toggle notifications on and verify notifications rescheduled
- [ ] Restart app and verify preference is persisted
- [ ] Test on Android 13+ (POST_NOTIFICATIONS permission)
- [ ] Test on older Android versions

## Technical Notes
- Uses SharedPreferences for simple key-value storage
- Default value: notifications enabled (`true`)
- When toggled off: cancels all scheduled notifications and daily refresh job
- When toggled on: reschedules all notifications via `rescheduleAllNotifications()`
- NotificationScheduler checks preference before scheduling

🤖 Generated with [Claude Code](https://claude.com/claude-code)