### PR TITLE
Material 3のダイナミックカラーに対応

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/MainActivity.kt
+++ b/app/src/main/java/net/shugo/medicineshield/MainActivity.kt
@@ -12,9 +12,12 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -112,7 +115,27 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun MedicineShieldTheme(content: @Composable () -> Unit) {
+    val context = LocalContext.current
+    val isDarkTheme = isSystemInDarkTheme()
+
+    // Android 12以降でダイナミックカラーを使用
+    val colorScheme = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        if (isDarkTheme) {
+            dynamicDarkColorScheme(context)
+        } else {
+            dynamicLightColorScheme(context)
+        }
+    } else {
+        // Android 12未満ではデフォルトのMaterial 3カラースキームを使用
+        if (isDarkTheme) {
+            androidx.compose.material3.darkColorScheme()
+        } else {
+            androidx.compose.material3.lightColorScheme()
+        }
+    }
+
     MaterialTheme(
+        colorScheme = colorScheme,
         content = content
     )
 }


### PR DESCRIPTION
## 概要
- Android 12 (API 31)以降でMaterial 3のダイナミックカラーに対応し、システムの壁紙に合わせたカラーテーマを自動適用
- Android 12未満のデバイスでは通常のMaterial 3カラースキームを使用
- ダークモード/ライトモードの自動切り替えに対応

## テスト計画
- [x] Android 12以降のデバイスで、壁紙を変更した際にアプリのカラーテーマが自動的に変更されることを確認
- [x] ダークモード/ライトモードを切り替えて、適切なカラースキームが適用されることを確認
- [ ] Android 12未満のデバイスで、デフォルトのMaterial 3カラースキームが正しく表示されることを確認
- [x] 各画面（日々の服薬、お薬一覧、設定画面など）で色が適切に適用されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)