### PR TITLE
Fix status bar appearance for light theme

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/MainActivity.kt
+++ b/app/src/main/java/net/shugo/medicineshield/MainActivity.kt
@@ -8,6 +8,7 @@ import android.os.Build
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
@@ -61,6 +62,9 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Enable edge-to-edge display with proper status bar appearance
+        enableEdgeToEdge()
 
         val database = AppDatabase.getDatabase(applicationContext)
         repository = MedicationRepository(


### PR DESCRIPTION
## Summary
- Add `enableEdgeToEdge()` to properly handle status bar appearance
- Ensure status bar icons are visible on both light and dark backgrounds

## Problem
When using the app with a light theme, the status bar icons (time, battery, etc.) were white/light colored, making them invisible against the light background of the app.

## Solution
The `enableEdgeToEdge()` function automatically adjusts the status bar icon colors based on the current theme:
- Light theme: Status bar icons become dark (readable on light background)
- Dark theme: Status bar icons become light (readable on dark background)

## Changes
**MainActivity.kt**:
- Added import for `androidx.activity.enableEdgeToEdge`
- Call `enableEdgeToEdge()` in `onCreate()` before `setContent()`

## Benefits
- Status bar icons are now always readable
- Proper contrast maintained automatically
- Modern Android edge-to-edge experience

## Test plan
- [x] Build succeeds without errors
- [ ] Test app with light theme (status bar icons should be dark)
- [ ] Test app with dark theme (status bar icons should be light)
- [ ] Verify on Android 12+ with dynamic colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)