### PR TITLE
Add a back button to MedicationListScreen

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/MainActivity.kt
+++ b/app/src/main/java/net/shugo/medicineshield/MainActivity.kt
@@ -198,6 +198,9 @@ fun MedicineShieldApp(repository: MedicationRepository) {
             )
             MedicationListScreen(
                 viewModel = viewModel,
+                onNavigateBack = {
+                    navController.popBackStack()
+                },
                 onAddMedication = {
                     navController.navigate("add_medication")
                 },

--- a/app/src/main/java/net/shugo/medicineshield/ui/screen/MedicationListScreen.kt
+++ b/app/src/main/java/net/shugo/medicineshield/ui/screen/MedicationListScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.*
@@ -26,6 +27,7 @@ import java.util.*
 @Composable
 fun MedicationListScreen(
     viewModel: MedicationListViewModel,
+    onNavigateBack: () -> Unit,
     onAddMedication: () -> Unit,
     onEditMedication: (Long) -> Unit
 ) {
@@ -37,7 +39,15 @@ fun MedicationListScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text(stringResource(R.string.medication_list_title)) }
+                title = { Text(stringResource(R.string.medication_list_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateBack) {
+                        Icon(
+                            imageVector = Icons.Default.ArrowBack,
+                            contentDescription = stringResource(R.string.back)
+                        )
+                    }
+                }
             )
         },
         floatingActionButton = {


### PR DESCRIPTION
A user in the closed test found it confusing that he could only return to the Daily Medication Screen using gesture navigation.