### PR TITLE
Optimize notification lookahead from 365 days to 7 days

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/notification/NotificationScheduler.kt
+++ b/app/src/main/java/net/shugo/medicineshield/notification/NotificationScheduler.kt
@@ -190,8 +190,9 @@ class NotificationScheduler(
             calendar.add(Calendar.DAY_OF_YEAR, 1)
         }
 
-        // その時刻に服用すべき薬があるか最大365日先までチェック
-        for (i in 0 until 365) {
+        // その時刻に服用すべき薬があるか最大7日先までチェック
+        // 毎日深夜0時に再スケジュールされるため、7日で十分
+        for (i in 0 until 7) {
             val medications = getMedicationsForTime(time, calendar.timeInMillis)
             if (medications.isNotEmpty()) {
                 return calendar.timeInMillis


### PR DESCRIPTION
Since DailyRefreshReceiver reschedules all notifications every day at midnight, there's no need to look ahead 365 days. 7 days is sufficient:
- DAILY medications: found within 1 day
- WEEKLY medications: found within 7 days max
- INTERVAL medications: found within 7 days due to daily rescheduling

This change improves performance by reducing unnecessary date iterations from 365 to 7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)