### PR TITLE
Include date in notification ID to distinguish cross-day notifications

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/notification/MedicationNotificationReceiver.kt
+++ b/app/src/main/java/net/shugo/medicineshield/notification/MedicationNotificationReceiver.kt
@@ -39,7 +39,7 @@ class MedicationNotificationReceiver : BroadcastReceiver() {
                 if (medications.isNotEmpty()) {
                     val notificationHelper = NotificationHelper(context)
                     val notificationId = NotificationScheduler(context, repository)
-                        .getNotificationIdForTime(time)
+                        .getNotificationIdForTime(time, scheduledDate)
                     notificationHelper.showMedicationNotification(
                         medications,
                         time,


### PR DESCRIPTION
Changed notification ID format from time-only (e.g., 900 for 09:00) to date+time (MMDDHHMM format, e.g., 10190700 for Oct 19 07:00). This ensures notifications are uniquely identified across day boundaries.

Modified getNotificationIdForTime() to accept scheduledDate parameter and generate 8-digit IDs (within Int max value: 2,147,483,647). Updated cancelNotificationForTime() to cancel notifications for 7 days ahead since IDs now include dates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)