### PR TITLE
Fix today_with_date string not respecting language settings

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/viewmodel/DailyMedicationViewModel.kt
+++ b/app/src/main/java/net/shugo/medicineshield/viewmodel/DailyMedicationViewModel.kt
@@ -13,10 +13,12 @@ import net.shugo.medicineshield.R
 import net.shugo.medicineshield.data.model.DailyMedicationItem
 import net.shugo.medicineshield.data.model.DailyNote
 import net.shugo.medicineshield.data.model.MedicationIntakeStatus
+import net.shugo.medicineshield.data.preferences.SettingsPreferences
 import net.shugo.medicineshield.data.repository.MedicationRepository
 import net.shugo.medicineshield.notification.NotificationHelper
 import net.shugo.medicineshield.notification.NotificationScheduler
 import net.shugo.medicineshield.utils.DateUtils
+import net.shugo.medicineshield.utils.LocaleHelper
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
@@ -107,7 +109,12 @@ class DailyMedicationViewModel(
 
         val dateText = dateFormat.format(calendar.time)
         _displayDateText.value = if (isToday) {
-            getApplication<Application>().getString(R.string.today_with_date, dateText)
+            // Wrap application context with configured language to get localized string
+            val application = getApplication<Application>()
+            val settingsPreferences = SettingsPreferences(application)
+            val language = settingsPreferences.getLanguage()
+            val localizedContext = LocaleHelper.wrap(application, language)
+            localizedContext.getString(R.string.today_with_date, dateText)
         } else {
             dateText
         }


### PR DESCRIPTION
## Summary
- Fixed issue where "today_with_date" string was displayed in system default language instead of user-configured language
- Updated `DailyMedicationViewModel` to wrap Application context with `LocaleHelper` before retrieving string resource
- Added imports for `SettingsPreferences` and `LocaleHelper`

## Root Cause
The `DailyMedicationViewModel.updateDisplayDate()` method was calling `getApplication<Application>().getString()` directly, which doesn't reflect Activity-level locale settings configured via `MainActivity.attachBaseContext()`. This caused the "Today %s" prefix to always appear in the system default language.

## Solution
Modified the `updateDisplayDate()` method to:
1. Retrieve the configured language from `SettingsPreferences`
2. Wrap the Application context using `LocaleHelper.wrap()`
3. Use the wrapped context to retrieve the localized string resource

## Test Plan
- [x] Change language in Settings to Japanese, restart app, verify "今日" appears with today's date
- [x] Change language to English, restart app, verify "Today" appears with today's date
- [x] Change language to Chinese (Simplified/Traditional), restart app, verify "今天" appears
- [x] Change language to Korean, restart app, verify "오늘" appears
- [x] Verify date navigation (previous/next day) still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)