### PR TITLE
Fix white screen bug when tapping after navigation

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/MainActivity.kt
+++ b/app/src/main/java/net/shugo/medicineshield/MainActivity.kt
@@ -27,6 +27,7 @@ import androidx.core.content.ContextCompat
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -192,6 +193,15 @@ fun MedicineShieldTheme(content: @Composable () -> Unit) {
     )
 }
 
+/**
+ * Safely pops the back stack, preventing the start destination from being popped
+ */
+fun NavController.safePopBackStack() {
+    if (previousBackStackEntry != null) {
+        popBackStack()
+    }
+}
+
 @Composable
 fun MedicineShieldApp(
     repository: MedicationRepository,
@@ -237,9 +247,7 @@ fun MedicineShieldApp(
             )
             SettingsScreen(
                 viewModel = viewModel,
-                onNavigateBack = {
-                    navController.popBackStack()
-                },
+                onNavigateBack = { navController.safePopBackStack() },
                 onRestartApp = onRestartApp
             )
         }
@@ -250,9 +258,7 @@ fun MedicineShieldApp(
             )
             MedicationListScreen(
                 viewModel = viewModel,
-                onNavigateBack = {
-                    navController.popBackStack()
-                },
+                onNavigateBack = { navController.safePopBackStack() },
                 onAddMedication = {
                     navController.navigate("add_medication")
                 },
@@ -269,9 +275,7 @@ fun MedicineShieldApp(
             MedicationFormScreen(
                 viewModel = viewModel,
                 isEdit = false,
-                onNavigateBack = {
-                    navController.popBackStack()
-                }
+                onNavigateBack = { navController.safePopBackStack() }
             )
         }
 
@@ -287,9 +291,7 @@ fun MedicineShieldApp(
             MedicationFormScreen(
                 viewModel = viewModel,
                 isEdit = true,
-                onNavigateBack = {
-                    navController.popBackStack()
-                }
+                onNavigateBack = { navController.safePopBackStack() }
             )
         }
     }


### PR DESCRIPTION
## Summary

Fixed a critical navigation bug where the app displayed a blank white screen after navigating back from Settings and quickly tapping the same position (top-left area where the back button was located).

## Problem

When users navigated back from the Settings screen and quickly tapped the top-left area of the Daily Medication screen (where the Settings back button used to be), the following occurred:

1. First tap: Navigated back from Settings to Daily Medication (normal behavior)
2. Second tap: Triggered the lingering click handler from the Settings back button
3. Result: `popBackStack()` was called twice, removing the start destination from the back stack
4. Final state: Blank white screen with no way to navigate back

## Root Cause

The issue was caused by Compose's recomposition timing. When navigation occurred, the previous screen's UI remained briefly in memory with active click handlers. If the user tapped quickly in the same position, the old button's `onClick` handler would fire, causing an additional `popBackStack()` call.

Since there was no check to prevent popping the start destination, the back stack became completely empty, resulting in a blank screen.

## Solution

Implemented a safe navigation pattern:

1. **Created `NavController.safePopBackStack()` extension function** that checks if `previousBackStackEntry` exists before calling `popBackStack()`
2. **Refactored all navigation callbacks** to use the safe method instead of direct `popBackStack()` calls
3. **Applied consistently across all screens**: Settings, Medication List, Add Medication, and Edit Medication

## Changes

### Modified Files
- `app/src/main/java/net/shugo/medicineshield/MainActivity.kt`

### Key Changes
- Added `NavController.safePopBackStack()` extension function (line 199-203)
- Replaced `onNavigateBack` implementations in all composable screens (lines 250, 261, 278, 294)

## Test Plan

To verify the fix:
1. Navigate to Settings screen
2. Tap the back button to return to Daily Medication
3. Immediately tap the same position (top-left) where the back button was
4. ✅ Expected: App remains on Daily Medication screen (no crash, no white screen)
5. ✅ Expected: System back gesture still works normally

## Benefits

- **Bug Fix**: Eliminates the white screen issue
- **Code Quality**: Consolidates duplicate navigation logic into a single reusable function
- **Maintainability**: Future screens can use the same safe navigation pattern
- **Prevention**: Protects against similar issues in other navigation scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)