### PR TITLE
Add reminder settings translations to all supported languages

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -102,6 +102,10 @@
     <string name="notification_settings">Benachrichtigungseinstellungen</string>
     <string name="enable_notifications">Benachrichtigungen aktivieren</string>
     <string name="notification_description">Erinnerungen erhalten, wenn es Zeit ist, Medikamente einzunehmen</string>
+    <string name="enable_reminder">Erinnerungs-Benachrichtigungen aktivieren</string>
+    <string name="reminder_description">Erinnerung senden, wenn Medikament nicht eingenommen wurde</string>
+    <string name="reminder_delay">Erinnerungsverzögerung (Minuten)</string>
+    <string name="reminder_delay_description">Wartezeit vor dem Senden der Erinnerung</string>
     <string name="app_info">App-Informationen</string>
     <string name="version">Version</string>
     <string name="license_info">Lizenzinformationen</string>
@@ -117,6 +121,10 @@
     <string name="notification_message_single">Bitte nehmen Sie %s ein</string>
     <string name="notification_message_multiple">Bitte nehmen Sie %s ein</string>
     <string name="medication_list_separator">,&#160;</string>
+    <string name="reminder_channel_name">Medikamenten-Erinnerungsbenachrichtigungen</string>
+    <string name="reminder_channel_description">Erinnert Sie, wenn Medikamente nicht eingenommen wurden</string>
+    <string name="reminder_notification_title">Medikamenten-Erinnerung (%s)</string>
+    <string name="reminder_notification_message">Sie haben %s noch nicht eingenommen</string>
 
     <!-- As-Needed Medication -->
     <string name="as_needed_medication">Bei Bedarf</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -102,6 +102,10 @@
     <string name="notification_settings">Configuración de notificaciones</string>
     <string name="enable_notifications">Activar notificaciones</string>
     <string name="notification_description">Reciba recordatorios cuando sea hora de tomar medicamentos</string>
+    <string name="enable_reminder">Activar notificaciones de recordatorio</string>
+    <string name="reminder_description">Enviar recordatorio si no se toma el medicamento</string>
+    <string name="reminder_delay">Retraso del recordatorio (minutos)</string>
+    <string name="reminder_delay_description">Tiempo de espera antes de enviar el recordatorio</string>
     <string name="app_info">Información de la aplicación</string>
     <string name="version">Versión</string>
     <string name="license_info">Información de licencia</string>
@@ -117,6 +121,10 @@
     <string name="notification_message_single">Por favor tome %s</string>
     <string name="notification_message_multiple">Por favor tome %s</string>
     <string name="medication_list_separator">,&#160;</string>
+    <string name="reminder_channel_name">Notificaciones de recordatorio de medicamentos</string>
+    <string name="reminder_channel_description">Le recuerda si no ha tomado el medicamento</string>
+    <string name="reminder_notification_title">Recordatorio de medicamento (%s)</string>
+    <string name="reminder_notification_message">Aún no ha tomado %s</string>
 
     <!-- As-Needed Medication -->
     <string name="as_needed_medication">Según necesidad</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -102,6 +102,10 @@
     <string name="notification_settings">Paramètres de notification</string>
     <string name="enable_notifications">Activer les notifications</string>
     <string name="notification_description">Recevoir des rappels quand il est temps de prendre un médicament</string>
+    <string name="enable_reminder">Activer les notifications de rappel</string>
+    <string name="reminder_description">Envoyer un rappel si le médicament n\'est pas pris</string>
+    <string name="reminder_delay">Délai de rappel (minutes)</string>
+    <string name="reminder_delay_description">Temps d\'attente avant d\'envoyer le rappel</string>
     <string name="app_info">Informations sur l\'application</string>
     <string name="version">Version</string>
     <string name="license_info">Informations de licence</string>
@@ -117,6 +121,10 @@
     <string name="notification_message_single">Veuillez prendre %s</string>
     <string name="notification_message_multiple">Veuillez prendre %s</string>
     <string name="medication_list_separator">,&#160;</string>
+    <string name="reminder_channel_name">Notifications de rappel de médicament</string>
+    <string name="reminder_channel_description">Vous rappelle si le médicament n\'est pas pris</string>
+    <string name="reminder_notification_title">Rappel de médicament (%s)</string>
+    <string name="reminder_notification_message">Vous n\'avez pas encore pris %s</string>
 
     <!-- As-Needed Medication -->
     <string name="as_needed_medication">Si nécessaire</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -102,6 +102,10 @@
     <string name="notification_settings">Impostazioni notifiche</string>
     <string name="enable_notifications">Abilita notifiche</string>
     <string name="notification_description">Ricevi promemoria quando è ora di prendere i farmaci</string>
+    <string name="enable_reminder">Abilita notifiche promemoria</string>
+    <string name="reminder_description">Invia promemoria se il farmaco non è stato preso</string>
+    <string name="reminder_delay">Ritardo promemoria (minuti)</string>
+    <string name="reminder_delay_description">Tempo di attesa prima di inviare il promemoria</string>
     <string name="app_info">Informazioni app</string>
     <string name="version">Versione</string>
     <string name="license_info">Informazioni licenza</string>
@@ -117,6 +121,10 @@
     <string name="notification_message_single">Per favore prendi %s</string>
     <string name="notification_message_multiple">Per favore prendi %s</string>
     <string name="medication_list_separator">,&#160;</string>
+    <string name="reminder_channel_name">Notifiche promemoria farmaci</string>
+    <string name="reminder_channel_description">Ti ricorda se il farmaco non è stato preso</string>
+    <string name="reminder_notification_title">Promemoria farmaco (%s)</string>
+    <string name="reminder_notification_message">Non hai ancora preso %s</string>
 
     <!-- As-Needed Medication -->
     <string name="as_needed_medication">Al bisogno</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -102,6 +102,10 @@
     <string name="notification_settings">알림 설정</string>
     <string name="enable_notifications">알림 사용</string>
     <string name="notification_description">복약 시각에 리마인더 받기</string>
+    <string name="enable_reminder">재알림 활성화</string>
+    <string name="reminder_description">복용하지 않은 경우 재알림 전송</string>
+    <string name="reminder_delay">재알림 대기 시간(분)</string>
+    <string name="reminder_delay_description">재알림을 보내기 전 대기 시간</string>
     <string name="app_info">앱 정보</string>
     <string name="version">버전</string>
     <string name="license_info">라이선스 정보</string>
@@ -117,6 +121,10 @@
     <string name="notification_message_single">%s 를 복용하세요</string>
     <string name="notification_message_multiple">%s 를 복용하세요</string>
     <string name="medication_list_separator">、</string>
+    <string name="reminder_channel_name">복약 재알림</string>
+    <string name="reminder_channel_description">복용하지 않은 경우 재알림을 보냅니다</string>
+    <string name="reminder_notification_title">복용 리마인더 (%s)</string>
+    <string name="reminder_notification_message">아직 %s 를 복용하지 않았습니다</string>
 
     <!-- As-Needed Medication -->
     <string name="as_needed_medication">임시 복용</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -102,6 +102,10 @@
     <string name="notification_settings">Definições de notificações</string>
     <string name="enable_notifications">Ativar notificações</string>
     <string name="notification_description">Receba lembretes quando for hora de tomar medicamentos</string>
+    <string name="enable_reminder">Ativar notificações de lembrete</string>
+    <string name="reminder_description">Enviar lembrete se o medicamento não for tomado</string>
+    <string name="reminder_delay">Atraso do lembrete (minutos)</string>
+    <string name="reminder_delay_description">Tempo de espera antes de enviar o lembrete</string>
     <string name="app_info">Informações da aplicação</string>
     <string name="version">Versão</string>
     <string name="license_info">Informações de licença</string>
@@ -117,6 +121,10 @@
     <string name="notification_message_single">Por favor tome %s</string>
     <string name="notification_message_multiple">Por favor tome %s</string>
     <string name="medication_list_separator">,&#160;</string>
+    <string name="reminder_channel_name">Notificações de lembrete de medicamento</string>
+    <string name="reminder_channel_description">Lembra-o se o medicamento não for tomado</string>
+    <string name="reminder_notification_title">Lembrete de medicamento (%s)</string>
+    <string name="reminder_notification_message">Ainda não tomou %s</string>
 
     <!-- As-Needed Medication -->
     <string name="as_needed_medication">Se necessário</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -102,6 +102,10 @@
     <string name="notification_settings">通知设置</string>
     <string name="enable_notifications">启用通知</string>
     <string name="notification_description">在服药时间接收提醒</string>
+    <string name="enable_reminder">启用再次提醒通知</string>
+    <string name="reminder_description">如果未服药则发送提醒</string>
+    <string name="reminder_delay">提醒延迟（分钟）</string>
+    <string name="reminder_delay_description">发送提醒前的等待时间</string>
     <string name="app_info">应用信息</string>
     <string name="version">版本</string>
     <string name="license_info">许可证信息</string>
@@ -117,6 +121,10 @@
     <string name="notification_message_single">请服用 %s</string>
     <string name="notification_message_multiple">请服用 %s</string>
     <string name="medication_list_separator">、</string>
+    <string name="reminder_channel_name">服药再次提醒通知</string>
+    <string name="reminder_channel_description">如果未服药则提醒您</string>
+    <string name="reminder_notification_title">服药提醒 (%s)</string>
+    <string name="reminder_notification_message">您还没有服用 %s</string>
 
     <!-- As-Needed Medication -->
     <string name="as_needed_medication">临时用药</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -102,6 +102,10 @@
     <string name="notification_settings">通知設定</string>
     <string name="enable_notifications">啟用通知</string>
     <string name="notification_description">在服藥時間接收提醒</string>
+    <string name="enable_reminder">啟用再次提醒通知</string>
+    <string name="reminder_description">如果未服藥則發送提醒</string>
+    <string name="reminder_delay">提醒延遲（分鐘）</string>
+    <string name="reminder_delay_description">發送提醒前的等待時間</string>
     <string name="app_info">應用程式資訊</string>
     <string name="version">版本</string>
     <string name="license_info">授權資訊</string>
@@ -117,6 +121,10 @@
     <string name="notification_message_single">請服用 %s</string>
     <string name="notification_message_multiple">請服用 %s</string>
     <string name="medication_list_separator">、</string>
+    <string name="reminder_channel_name">服藥再次提醒通知</string>
+    <string name="reminder_channel_description">如果未服藥則提醒您</string>
+    <string name="reminder_notification_title">服藥提醒 (%s)</string>
+    <string name="reminder_notification_message">您還沒有服用 %s</string>
 
     <!-- As-Needed Medication -->
     <string name="as_needed_medication">臨時用藥</string>


### PR DESCRIPTION
Fixes #91

Translated 8 reminder-related string resources to German, Spanish, French, Italian, Korean, Portuguese, Chinese (Simplified), and Chinese (Traditional). Japanese translations were already present.

### String Resources Translated
- `enable_reminder`, `reminder_description`, `reminder_delay`, `reminder_delay_description`
- `reminder_channel_name`, `reminder_channel_description`, `reminder_notification_title`, `reminder_notification_message`

### Languages Updated
- German (de)
- Spanish (es)
- French (fr)
- Italian (it)
- Korean (ko)
- Portuguese (pt)
- Chinese Simplified (zh-rCN)
- Chinese Traditional (zh-rTW)

Generated with [Claude Code](https://claude.ai/code)