### PR TITLE
Change medication deletion behavior to stop medication instead

### DIFF
--- a/app/src/main/java/net/shugo/medicineshield/viewmodel/MedicationListViewModel.kt
+++ b/app/src/main/java/net/shugo/medicineshield/viewmodel/MedicationListViewModel.kt
@@ -79,6 +79,14 @@ class MedicationListViewModel(
         }
     }
 
+    fun stopMedication(medicationId: Long) {
+        viewModelScope.launch {
+            repository.stopMedication(medicationId)
+            // Reschedule notifications (medication will no longer appear in daily list from today)
+            notificationScheduler.rescheduleAllNotifications()
+        }
+    }
+
     /**
      * Convert Long timestamp to yyyy-MM-dd format string
      */

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -29,6 +29,7 @@
     <string name="delete">Löschen</string>
     <string name="delete_confirmation_title">Bestätigen</string>
     <string name="delete_confirmation_message">Alle Einnahmehistorien werden ebenfalls gelöscht.\nSind Sie sicher, dass Sie dieses Medikament löschen möchten?</string>
+    <string name="stop_medication_confirmation_message">Dieses Medikament wird in die Registerkarte \"Vergangene Medikamente\" verschoben.\nMöchten Sie die Einnahme beenden?</string>
     <string name="yes">Ja</string>
     <string name="no">Nein</string>
     <string name="medication_times_label">Zeiten: %s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -29,6 +29,7 @@
     <string name="delete">Eliminar</string>
     <string name="delete_confirmation_title">Confirmar</string>
     <string name="delete_confirmation_message">Todo el historial de tomas también será eliminado.\n¿Está seguro de que desea eliminar este medicamento?</string>
+    <string name="stop_medication_confirmation_message">Este medicamento se moverá a la pestaña \"Medicamentos pasados\".\n¿Desea dejar de tomarlo?</string>
     <string name="yes">Sí</string>
     <string name="no">No</string>
     <string name="medication_times_label">Horarios: %s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -29,6 +29,7 @@
     <string name="delete">Supprimer</string>
     <string name="delete_confirmation_title">Confirmer</string>
     <string name="delete_confirmation_message">Tout l\'historique de prise sera également supprimé.\nÊtes-vous sûr de vouloir supprimer ce médicament ?</string>
+    <string name="stop_medication_confirmation_message">Ce médicament sera déplacé vers l\'onglet \"Médicaments passés\".\nVoulez-vous arrêter de le prendre ?</string>
     <string name="yes">Oui</string>
     <string name="no">Non</string>
     <string name="medication_times_label">Horaires : %s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -29,6 +29,7 @@
     <string name="delete">Elimina</string>
     <string name="delete_confirmation_title">Conferma</string>
     <string name="delete_confirmation_message">Anche tutta la cronologia di assunzione verrà eliminata.\nSei sicuro di voler eliminare questo farmaco?</string>
+    <string name="stop_medication_confirmation_message">Questo farmaco verrà spostato nella scheda \"Farmaci passati\".\nVuoi smettere di prenderlo?</string>
     <string name="yes">Sì</string>
     <string name="no">No</string>
     <string name="medication_times_label">Orari: %s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -29,6 +29,7 @@
     <string name="delete">削除</string>
     <string name="delete_confirmation_title">確認</string>
     <string name="delete_confirmation_message">服用履歴も削除されます。\n本当にこのお薬を削除しますか?</string>
+    <string name="stop_medication_confirmation_message">このお薬は「過去のお薬」タブに移動します。\n服用を中止しますか?</string>
     <string name="yes">はい</string>
     <string name="no">いいえ</string>
     <string name="medication_times_label">服用時間: %s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -29,6 +29,7 @@
     <string name="delete">삭제</string>
     <string name="delete_confirmation_title">확인</string>
     <string name="delete_confirmation_message">복용 이력도 삭제됩니다.\n정말 이 약품을 삭제하시겠습니까?</string>
+    <string name="stop_medication_confirmation_message">이 약품은 \"과거 약품\" 탭으로 이동합니다.\n복용을 중단하시겠습니까?</string>
     <string name="yes">예</string>
     <string name="no">아니오</string>
     <string name="medication_times_label">복용 시간: %s</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -29,6 +29,7 @@
     <string name="delete">Eliminar</string>
     <string name="delete_confirmation_title">Confirmar</string>
     <string name="delete_confirmation_message">Todo o histórico de tomas também será eliminado.\nTem a certeza de que deseja eliminar este medicamento?</string>
+    <string name="stop_medication_confirmation_message">Este medicamento será movido para o separador \"Medicamentos passados\".\nDeseja parar de tomá-lo?</string>
     <string name="yes">Sim</string>
     <string name="no">Não</string>
     <string name="medication_times_label">Horários: %s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -29,6 +29,7 @@
     <string name="delete">删除</string>
     <string name="delete_confirmation_title">确认</string>
     <string name="delete_confirmation_message">服用记录也会被删除。\n您确定要删除这个药品吗？</string>
+    <string name="stop_medication_confirmation_message">该药品将移动到"过去的药品"标签。\n您要停止服用吗？</string>
     <string name="yes">是</string>
     <string name="no">否</string>
     <string name="medication_times_label">服用时间：%s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -29,6 +29,7 @@
     <string name="delete">刪除</string>
     <string name="delete_confirmation_title">確認</string>
     <string name="delete_confirmation_message">服用記錄也會被刪除。\n您確定要刪除這個藥品嗎？</string>
+    <string name="stop_medication_confirmation_message">該藥品將移動到「過去的藥品」標籤。\n您要停止服用嗎？</string>
     <string name="yes">是</string>
     <string name="no">否</string>
     <string name="medication_times_label">服用時間：%s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
     <string name="delete">Delete</string>
     <string name="delete_confirmation_title">Confirm</string>
     <string name="delete_confirmation_message">All intake history will also be deleted.\nAre you sure you want to delete this medication?</string>
+    <string name="stop_medication_confirmation_message">This medication will be moved to the \"Past Medications\" tab.\nDo you want to stop taking it?</string>
     <string name="yes">Yes</string>
     <string name="no">No</string>
     <string name="medication_times_label">Times: %s</string>


### PR DESCRIPTION
## Summary
- When deleting a medication from the "Current" tab, it is now moved to "Past Medications" instead of being permanently deleted
- The medication's end date is set to yesterday, preserving intake history
- Past medications continue to use permanent deletion behavior
- Updated confirmation messages for both scenarios in all 10 supported languages

## Changes
- **MedicationRepository**: Added `stopMedication()` method that creates a new temporal MedicationConfig record with `medicationEndDate` set to yesterday
- **MedicationListViewModel**: Added `stopMedication()` method to handle stopping medications
- **MedicationListScreen**: Added logic to track which tab the delete action originated from and call the appropriate method
- **String resources**: Added `stop_medication_confirmation_message` in all supported languages (en, ja, es, zh-CN, ko, zh-TW, fr, pt, it, de)

## Test Plan
- [ ] Verify deleting a medication from "Current" tab shows the new confirmation message
- [ ] Verify the medication appears in "Past Medications" tab after stopping
- [ ] Verify intake history is preserved when stopping a medication
- [ ] Verify deleting from "Past Medications" tab still permanently deletes
- [ ] Verify notification rescheduling works correctly after stopping a medication
- [ ] Test in different languages to verify confirmation messages display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)